### PR TITLE
Feature/swagger [Feat] swagger 문서화 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
+++ b/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
@@ -33,8 +33,8 @@ public class BoardController {
     @ApiResponse(responseCode = "201", description = "게시글 생성 성공", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
     @ApiResponse(responseCode = "400", description = "잘못된 요청 게시글", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
     @Operation(method = "POST", summary = "새 게시글 생성", description = "사용자가 게시글 생성하기 위한 API")
-    public ResponseEntity<CommonResDto<BoardResDto>> createBoard(@Valid @RequestBody BoardCreateReqDto BoardCreateReqDto) {
-        BoardResDto dto = boardService.createBoard(BoardCreateReqDto);
+    public ResponseEntity<CommonResDto<BoardResDto>> createBoard(@Valid @RequestBody BoardCreateReqDto boardCreateReqDto) {
+        BoardResDto dto = boardService.createBoard(boardCreateReqDto);
         return new ResponseEntity<>(new CommonResDto<>("게시글 생성", dto), HttpStatus.CREATED);
     }
 

--- a/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
+++ b/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
@@ -6,6 +6,12 @@ import com.soongsil.soongpal.board.dto.BoardResDto;
 import com.soongsil.soongpal.board.dto.BoardUpdateReqDto;
 import com.soongsil.soongpal.board.service.BoardService;
 import com.soongsil.soongpal.common.dto.CommonResDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,41 +24,64 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/board")
 @RestController
+@Tag(name = "Board Controller", description = "게시글 관련 CRUD 로직을 수행하는 Controller입니다")
 public class BoardController {
 
     private final BoardService boardService;
 
     @PostMapping
+    @ApiResponse(responseCode = "201", description = "게시글 생성 성공", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @ApiResponse(responseCode = "400", description = "잘못된 요청 게시글", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @Operation(method = "POST", summary = "새 게시글 생성", description = "사용자가 게시글 생성하기 위한 API")
     public ResponseEntity<CommonResDto<BoardResDto>> createBoard(@Valid @RequestBody BoardCreateReqDto BoardCreateReqDto) {
         BoardResDto dto = boardService.createBoard(BoardCreateReqDto);
         return new ResponseEntity<>(new CommonResDto<>("게시글 생성", dto), HttpStatus.CREATED);
     }
 
     @GetMapping
+    @ApiResponse(responseCode = "200", description = "모든 게시글 조회 성공", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @Operation(method = "GET", summary = "모든 게시글 조회", description = "모든 게시글을 조회하기 위한 API")
     public ResponseEntity<CommonResDto<List<BoardResDto>>> getAllBoards() {
         List<BoardResDto> dto = boardService.getAllBoards();
         return new ResponseEntity<>(new CommonResDto<>("모든 게시글 조회", dto), HttpStatus.OK);
     }
 
     @GetMapping("/status")
+    @ApiResponse(responseCode = "200", description = "상태별 게시글 조회 성공", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @ApiResponse(responseCode = "400", description = "유효하지 않은 상태 값", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @Parameter(name = "status", description = "조회할 게시글의 상태 (GROUP 또는 USED)", required = true)
+    @Operation(method = "GET", summary = "상태별 게시글 조회", description = "status[GROUP,USED]별 게시글 조회하기 위한 API")
     public ResponseEntity<CommonResDto<List<BoardResDto>>> getBoardsByStatus(@RequestParam BoardStatus status) {
         List<BoardResDto> dto = boardService.getBoardsByStatus(status); // 서비스 메서드 호출
         return new ResponseEntity<>(new CommonResDto<>("상태별 게시글 조회", dto), HttpStatus.OK);
     }
 
     @GetMapping("/{id}")
+    @ApiResponse(responseCode = "200", description = "게시글 상세 조회 성공", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @Parameter(name = "id", description = "조회할 게시글의 ID", required = true)
+    @Operation(method = "GET", summary = "게시글 상세 조회", description = "id를 통해 특정 게시글을 조회하기 위한 API")
     public ResponseEntity<CommonResDto<BoardResDto>> getBoardById(@PathVariable Long id) {
         BoardResDto dto = boardService.getBoardById(id);
         return new ResponseEntity<>(new CommonResDto<>("게시글 상세 조회", dto), HttpStatus.OK);
     }
 
     @PutMapping("/{id}")
+    @ApiResponse(responseCode = "200", description = "게시글 수정 성공", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @Parameter(name = "id", description = "조회할 게시글의 ID", required = true)
+    @Operation(method = "PUT", summary = "게시글 수정", description = "게시글의 데이터를 수정하기 위한 API")
     public ResponseEntity<CommonResDto<BoardResDto>> updateBoard(@PathVariable Long id, @Valid @RequestBody BoardUpdateReqDto boardUpdateReqDto) {
         BoardResDto dto = boardService.updateBoard(id, boardUpdateReqDto);
         return new ResponseEntity<>(new CommonResDto<>("게시글 수정", dto), HttpStatus.OK);
     }
 
     @DeleteMapping("/{id}")
+    @ApiResponse(responseCode = "200", description = "게시글 삭제 성공", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @Parameter(name = "id", description = "조회할 게시글의 ID", required = true)
+    @Operation(method = "DELETE", summary = "게시글 삭제", description = "게시글을 삭제하기 위한 API")
     public ResponseEntity<CommonResDto<BoardResDto>> deleteBoard(@PathVariable Long id) {
         BoardResDto dto = boardService.deleteBoard(id);
         return new ResponseEntity<>(new CommonResDto<>("게시글 삭제", dto), HttpStatus.OK);

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardCreateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardCreateReqDto.java
@@ -2,6 +2,7 @@ package com.soongsil.soongpal.board.dto;
 
 import com.soongsil.soongpal.board.domain.Board;
 import com.soongsil.soongpal.board.domain.BoardStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -10,15 +11,20 @@ import lombok.Getter;
 @Getter
 public class BoardCreateReqDto {
 
+    @Schema(description = "게시글의 제목", example = "콜라 30개 묶음 공동구매")
     @NotBlank
     private String title;
 
+    @Schema(description = "게시글의 내용", example = "전 10개만 필요해요!")
     @NotBlank
     private String content;
 
+    @Schema(description = "상품 관련 URL (선택 사항)", example = "https://example.com/cola")
     private String url;
+    @Schema(description = "모임 장소 또는 거래 위치 (선택 사항)", example = "기숙사 1층 로비")
     private String location;
 
+    @Schema(description = "게시글 상태", example = "GROUP", allowableValues = {"GROUP", "USED"})
     @NotNull
     private BoardStatus status;
 

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardCreateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardCreateReqDto.java
@@ -5,9 +5,12 @@ import com.soongsil.soongpal.board.domain.BoardStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class BoardCreateReqDto {
 

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardUpdateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardUpdateReqDto.java
@@ -1,5 +1,6 @@
 package com.soongsil.soongpal.board.dto;
 
+import com.soongsil.soongpal.board.domain.Board;
 import com.soongsil.soongpal.board.domain.BoardStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -32,4 +33,14 @@ public class BoardUpdateReqDto {
     @Schema(description = "수정할 게시글 상태", example = "USED", allowableValues = {"GROUP", "USED"})
     @NotNull
     private BoardStatus status;
+
+    public Board toEntity() {
+        return Board.builder()
+                .title(this.title)
+                .content(this.content)
+                .url(this.url)
+                .location(this.location)
+                .status(this.status)
+                .build();
+    }
 }

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardUpdateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardUpdateReqDto.java
@@ -1,6 +1,7 @@
 package com.soongsil.soongpal.board.dto;
 
 import com.soongsil.soongpal.board.domain.BoardStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -15,15 +16,20 @@ import lombok.Setter;
 @AllArgsConstructor
 public class BoardUpdateReqDto {
 
+    @Schema(description = "수정할 게시글의 제목", example = "제목 수정됨")
     @NotBlank
     private String title;
 
+    @Schema(description = "수정할 게시글의 내용", example = "이러이러한 내용으로 바뀌었어요.")
     @NotBlank
     private String content;
 
+    @Schema(description = "수정할 관련 웹 페이지 URL (선택 사항)", example = "http://new.example.com/link")
     private String url;
+    @Schema(description = "수정할 모임 장소 또는 거래 위치 (선택 사항)", example = "숭실대학교 한경직 기념관")
     private String location;
 
+    @Schema(description = "수정할 게시글 상태", example = "USED", allowableValues = {"GROUP", "USED"})
     @NotNull
     private BoardStatus status;
 }

--- a/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
+++ b/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
@@ -12,7 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.swing.*;
 import java.util.stream.Collectors;
 
 import java.util.List;
@@ -56,15 +55,7 @@ public class BoardService {
         Board findBoard = boardRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
 
-        findBoard.update(
-                Board.builder()
-                        .title(boardUpdateReqDto.getTitle())
-                        .content(boardUpdateReqDto.getContent())
-                        .url(boardUpdateReqDto.getUrl())
-                        .location(boardUpdateReqDto.getLocation())
-                        .status(boardUpdateReqDto.getStatus())
-                        .build()
-        );
+        findBoard.update(boardUpdateReqDto.toEntity());
         return BoardResDto.from(findBoard);
     }
 

--- a/src/main/java/com/soongsil/soongpal/config/SwaggerConfig.java
+++ b/src/main/java/com/soongsil/soongpal/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package com.soongsil.soongpal.config;
+
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("SoongPal API 문서")
+                .version("v1.0.0")
+                .description("숭실대학교 학생들을 위한 공동구매와 중고거래 플랫폼 입니다. 이 API 문서는 SoongPal의 API 사용법을 설명합니다.");
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(info);
+    }
+
+}


### PR DESCRIPTION
API 문서화와 테스트 편의성 향상을 위해 Swagger를 적용했습니다.

1. build.gradle에 springdoc-openapi-starter-webmvc-ui 의존성을 추가했습니다. 
2. API 문서의 기본 정보를 정의하기 위해 config/SwaggerConfig.java 설정 파일을 추가했습니다.
3. BoardController의 각 API 메서드와 BoardCreateReqDto, BoardUpdateReqDto 필드에 Swagger 어노테이션들을 적용했습니다.

DTO 필드의 @Schema 예시 값들이 적절한지와 BoardResDto에는 @Schema를 추가를 안했는데 괜찮은지 그 부분 한번 확인 부탁드려요!