### PR TITLE
Feature/search-title [Feat] 게시글 제목 검색 기능 구현

### DIFF
--- a/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
+++ b/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
@@ -86,4 +86,12 @@ public class BoardController {
         BoardResDto dto = boardService.deleteBoard(id);
         return new ResponseEntity<>(new CommonResDto<>("게시글 삭제", dto), HttpStatus.OK);
     }
+
+    @GetMapping("/search")
+    @Parameter(name = "keyword", description = "조회할 게시글의 제목", required = true)
+    @Operation(summary = "제목으로 게시글 검색", description = "데이터베이스에서 키워드가 포함된 게시글 제목으로 검색합니다.")
+    public ResponseEntity<List<BoardResDto>> searchBoardsByTitle(@RequestParam String keyword) {
+        List<BoardResDto> searchBoards = boardService.searchBoardsByTitle(keyword);
+        return new ResponseEntity<>(searchBoards, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/soongsil/soongpal/board/repository/BoardRepository.java
+++ b/src/main/java/com/soongsil/soongpal/board/repository/BoardRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
     List<Board> findByStatus(BoardStatus status);
+
+    List<Board> findByTitleContainingIgnoreCase(String keyword);
 }

--- a/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
+++ b/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
@@ -66,4 +66,12 @@ public class BoardService {
         boardRepository.deleteById(id);
         return BoardResDto.from(findBoard);
     }
+
+    public List<BoardResDto> searchBoardsByTitle(String keyword) {
+        List<Board> searchBoards = boardRepository.findByTitleContainingIgnoreCase(keyword);
+
+        return searchBoards.stream()
+                .map(BoardResDto::from)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION

RDBMS 기반 제목 검색 기능을 구현하였습니다. 

1. BoardRepository에 findByTitleContainingIgnoreCase(String titleKeyword) 메서드를 추가하여 제목에 특정 키워드가 포함된 게시글을 대소문자 구분 없이 검색 가능
2. BoardService의 searchBoardsByTitle 메서드와 BoardController의 GET /api/boards/search로 해당 검색 기능 추가