### PR TITLE
Feature/board [Feat] 게시글 카테고리 및 거래 상태 조회 기능 추가

### DIFF
--- a/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
+++ b/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
@@ -1,6 +1,6 @@
 package com.soongsil.soongpal.board.controller;
 
-import com.soongsil.soongpal.board.domain.BoardStatus;
+import com.soongsil.soongpal.board.domain.BoardCategory;
 import com.soongsil.soongpal.board.dto.BoardCreateReqDto;
 import com.soongsil.soongpal.board.dto.BoardResDto;
 import com.soongsil.soongpal.board.dto.BoardUpdateReqDto;
@@ -46,13 +46,13 @@ public class BoardController {
         return new ResponseEntity<>(new CommonResDto<>("모든 게시글 조회", dto), HttpStatus.OK);
     }
 
-    @GetMapping("/status")
-    @ApiResponse(responseCode = "200", description = "상태별 게시글 조회 성공", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
-    @ApiResponse(responseCode = "400", description = "유효하지 않은 상태 값", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
-    @Parameter(name = "status", description = "조회할 게시글의 상태 (GROUP 또는 USED)", required = true)
-    @Operation(method = "GET", summary = "상태별 게시글 조회", description = "status[GROUP,USED]별 게시글 조회하기 위한 API")
-    public ResponseEntity<CommonResDto<List<BoardResDto>>> getBoardsByStatus(@RequestParam BoardStatus status) {
-        List<BoardResDto> dto = boardService.getBoardsByStatus(status); // 서비스 메서드 호출
+    @GetMapping("/category")
+    @ApiResponse(responseCode = "200", description = "카테고리 별 게시글 조회 성공", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @ApiResponse(responseCode = "400", description = "유효하지 않은 카테고리 값", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @Parameter(name = "category", description = "조회할 게시글의 카테고리 상태 (GROUP 또는 USED)", required = true)
+    @Operation(method = "GET", summary = "카테고리 별 게시글 조회", description = "category[GROUP,USED]별 게시글 조회하기 위한 API")
+    public ResponseEntity<CommonResDto<List<BoardResDto>>> getBoardsByCategory(@RequestParam BoardCategory category) {
+        List<BoardResDto> dto = boardService.getBoardsByCategory(category); // 서비스 메서드 호출
         return new ResponseEntity<>(new CommonResDto<>("상태별 게시글 조회", dto), HttpStatus.OK);
     }
 

--- a/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
+++ b/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
@@ -1,6 +1,7 @@
 package com.soongsil.soongpal.board.controller;
 
 import com.soongsil.soongpal.board.domain.BoardCategory;
+import com.soongsil.soongpal.board.domain.BoardStatus;
 import com.soongsil.soongpal.board.dto.BoardCreateReqDto;
 import com.soongsil.soongpal.board.dto.BoardResDto;
 import com.soongsil.soongpal.board.dto.BoardUpdateReqDto;
@@ -87,11 +88,26 @@ public class BoardController {
         return new ResponseEntity<>(new CommonResDto<>("게시글 삭제", dto), HttpStatus.OK);
     }
 
-    @GetMapping("/search")
+    @GetMapping("/search/title")
     @Parameter(name = "keyword", description = "조회할 게시글의 제목", required = true)
     @Operation(summary = "제목으로 게시글 검색", description = "데이터베이스에서 키워드가 포함된 게시글 제목으로 검색합니다.")
     public ResponseEntity<List<BoardResDto>> searchBoardsByTitle(@RequestParam String keyword) {
         List<BoardResDto> searchBoards = boardService.searchBoardsByTitle(keyword);
         return new ResponseEntity<>(searchBoards, HttpStatus.OK);
     }
+
+    @GetMapping("/status")
+    @Operation(summary = "거래 상태별 게시글 조회", description = "특정 거래 상태(IN_PROGRESS, COMPLETED)의 게시글을 조회합니다.")
+    public ResponseEntity<CommonResDto<List<BoardResDto>>> getBoardsByStatus(@RequestParam BoardStatus status) {
+        List<BoardResDto> dto = boardService.getBoardsByStatus(status);
+        return new ResponseEntity<>(new CommonResDto<>("거래 상태별 게시글 조회", dto), HttpStatus.OK);
+    }
+
+    @GetMapping("/filter")
+    @Operation(summary = "카테고리별 거래 상태 게시글 조회", description = "특정 카테고리(GROUP, USED) 내에서 특정 거래 상태(IN_PROGRESS, COMPLETED)인 게시글을 조회합니다.")
+    public ResponseEntity<CommonResDto<List<BoardResDto>>> getBoardsByCategoryAndStatus(@RequestParam BoardCategory category, @RequestParam BoardStatus status) {
+        List<BoardResDto> dto = boardService.getBoardsByCategoryAndStatus(category, status);
+        return new ResponseEntity<>(new CommonResDto<>("카테고리별 거래 상태 게시글 조회", dto), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
+++ b/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
@@ -40,21 +40,33 @@ public class BoardController {
     }
 
     @GetMapping
-    @ApiResponse(responseCode = "200", description = "모든 게시글 조회 성공", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
-    @Operation(method = "GET", summary = "모든 게시글 조회", description = "모든 게시글을 조회하기 위한 API")
-    public ResponseEntity<CommonResDto<List<BoardResDto>>> getAllBoards() {
-        List<BoardResDto> dto = boardService.getAllBoards();
-        return new ResponseEntity<>(new CommonResDto<>("모든 게시글 조회", dto), HttpStatus.OK);
-    }
+    @ApiResponse(responseCode = "200", description = "게시글 조회 성공", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @ApiResponse(responseCode = "400", description = "유효하지 않은 파라미터 값", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    @Operation(method = "GET", summary = "게시글 목록 조회 및 필터링", description = "모든 게시글 또는 'keyword', 'category', 'status' 파라미터를 조합해 게시글을 조회합니다. 파라미터가 없으면 모든 게시글을 조회합니다.")
+    @Parameter(name = "keyword", description = "조회할 게시글의 제목 (선택 사항)", required = false)
+    @Parameter(name = "category", description = "조회할 게시글의 카테고리 (GROUP 또는 USED) (선택 사항)", required = false)
+    @Parameter(name = "status", description = "조회할 게시글의 거래 상태 (IN_PROGRESS 또는 COMPLETED) (선택 사항)", required = false)
+    public ResponseEntity<CommonResDto<List<BoardResDto>>> getBoards(@RequestParam(required = false) String keyword, @RequestParam(required = false) BoardCategory category, @RequestParam(required = false) BoardStatus status) {
+        List<BoardResDto> dto;
 
-    @GetMapping("/category")
-    @ApiResponse(responseCode = "200", description = "카테고리 별 게시글 조회 성공", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
-    @ApiResponse(responseCode = "400", description = "유효하지 않은 카테고리 값", content = @Content(schema = @Schema(implementation = CommonResDto.class)))
-    @Parameter(name = "category", description = "조회할 게시글의 카테고리 상태 (GROUP 또는 USED)", required = true)
-    @Operation(method = "GET", summary = "카테고리 별 게시글 조회", description = "category[GROUP,USED]별 게시글 조회하기 위한 API")
-    public ResponseEntity<CommonResDto<List<BoardResDto>>> getBoardsByCategory(@RequestParam BoardCategory category) {
-        List<BoardResDto> dto = boardService.getBoardsByCategory(category); // 서비스 메서드 호출
-        return new ResponseEntity<>(new CommonResDto<>("상태별 게시글 조회", dto), HttpStatus.OK);
+        if (keyword != null && !keyword.isEmpty()) {
+            // 키워드로 게시글 제목 검색
+            dto = boardService.searchBoardsByTitle(keyword);
+        }
+        else if (category != null && status != null) {
+            // 카테고리 + 상태 조합 검색
+            dto = boardService.getBoardsByCategoryAndStatus(category, status);
+        } else if (category != null) {
+            // 게시글 카테고리 검색
+            dto = boardService.getBoardsByCategory(category);
+        } else if (status != null) {
+            // 현재 게시글 상태 검색
+            dto = boardService.getBoardsByStatus(status);
+        } else {
+            // 모든 게시글 조회
+            dto = boardService.getAllBoards();
+        }
+        return new ResponseEntity<>(new CommonResDto<>("게시글 조회 성공", dto), HttpStatus.OK);
     }
 
     @GetMapping("/{id}")
@@ -86,31 +98,6 @@ public class BoardController {
     public ResponseEntity<CommonResDto<BoardResDto>> deleteBoard(@PathVariable Long id) {
         BoardResDto dto = boardService.deleteBoard(id);
         return new ResponseEntity<>(new CommonResDto<>("게시글 삭제", dto), HttpStatus.OK);
-    }
-
-    @GetMapping("/search")
-    @Parameter(name = "keyword", description = "조회할 게시글의 제목", required = true)
-    @Operation(summary = "제목으로 게시글 검색", description = "데이터베이스에서 키워드가 포함된 게시글 제목으로 검색합니다.")
-    public ResponseEntity<List<BoardResDto>> searchBoardsByTitle(@RequestParam String keyword) {
-        List<BoardResDto> searchBoards = boardService.searchBoardsByTitle(keyword);
-        return new ResponseEntity<>(searchBoards, HttpStatus.OK);
-    }
-
-    @GetMapping("/status")
-    @Parameter(name = "status", description = "조회할 게시글의 거래 상태 (IN_PROGRESS 또는 COMPLETED)", required = true)
-    @Operation(summary = "거래 상태별 게시글 조회", description = "특정 거래 상태(IN_PROGRESS, COMPLETED)의 게시글을 조회합니다.")
-    public ResponseEntity<CommonResDto<List<BoardResDto>>> getBoardsByStatus(@RequestParam BoardStatus status) {
-        List<BoardResDto> dto = boardService.getBoardsByStatus(status);
-        return new ResponseEntity<>(new CommonResDto<>("거래 상태별 게시글 조회", dto), HttpStatus.OK);
-    }
-
-    @GetMapping("/filter")
-    @Parameter(name = "category", description = "조회할 게시글의 카테고리 상태 (GROUP 또는 USED)", required = true)
-    @Parameter(name = "status", description = "조회할 게시글의 거래 상태 (IN_PROGRESS 또는 COMPLETED)", required = true)
-    @Operation(summary = "카테고리별 거래 상태 게시글 조회", description = "특정 카테고리(GROUP, USED) 내에서 특정 거래 상태(IN_PROGRESS, COMPLETED)인 게시글을 조회합니다.")
-    public ResponseEntity<CommonResDto<List<BoardResDto>>> getBoardsByCategoryAndStatus(@RequestParam BoardCategory category, @RequestParam BoardStatus status) {
-        List<BoardResDto> dto = boardService.getBoardsByCategoryAndStatus(category, status);
-        return new ResponseEntity<>(new CommonResDto<>("카테고리별 거래 상태 게시글 조회", dto), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
+++ b/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
@@ -97,6 +97,7 @@ public class BoardController {
     }
 
     @GetMapping("/status")
+    @Parameter(name = "status", description = "조회할 게시글의 거래 상태 (IN_PROGRESS 또는 COMPLETED)", required = true)
     @Operation(summary = "거래 상태별 게시글 조회", description = "특정 거래 상태(IN_PROGRESS, COMPLETED)의 게시글을 조회합니다.")
     public ResponseEntity<CommonResDto<List<BoardResDto>>> getBoardsByStatus(@RequestParam BoardStatus status) {
         List<BoardResDto> dto = boardService.getBoardsByStatus(status);
@@ -104,6 +105,8 @@ public class BoardController {
     }
 
     @GetMapping("/filter")
+    @Parameter(name = "category", description = "조회할 게시글의 카테고리 상태 (GROUP 또는 USED)", required = true)
+    @Parameter(name = "status", description = "조회할 게시글의 거래 상태 (IN_PROGRESS 또는 COMPLETED)", required = true)
     @Operation(summary = "카테고리별 거래 상태 게시글 조회", description = "특정 카테고리(GROUP, USED) 내에서 특정 거래 상태(IN_PROGRESS, COMPLETED)인 게시글을 조회합니다.")
     public ResponseEntity<CommonResDto<List<BoardResDto>>> getBoardsByCategoryAndStatus(@RequestParam BoardCategory category, @RequestParam BoardStatus status) {
         List<BoardResDto> dto = boardService.getBoardsByCategoryAndStatus(category, status);

--- a/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
+++ b/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
@@ -88,7 +88,7 @@ public class BoardController {
         return new ResponseEntity<>(new CommonResDto<>("게시글 삭제", dto), HttpStatus.OK);
     }
 
-    @GetMapping("/search/title")
+    @GetMapping("/search")
     @Parameter(name = "keyword", description = "조회할 게시글의 제목", required = true)
     @Operation(summary = "제목으로 게시글 검색", description = "데이터베이스에서 키워드가 포함된 게시글 제목으로 검색합니다.")
     public ResponseEntity<List<BoardResDto>> searchBoardsByTitle(@RequestParam String keyword) {

--- a/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
+++ b/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
@@ -47,25 +47,7 @@ public class BoardController {
     @Parameter(name = "category", description = "조회할 게시글의 카테고리 (GROUP 또는 USED) (선택 사항)", required = false)
     @Parameter(name = "status", description = "조회할 게시글의 거래 상태 (IN_PROGRESS 또는 COMPLETED) (선택 사항)", required = false)
     public ResponseEntity<CommonResDto<List<BoardResDto>>> getBoards(@RequestParam(required = false) String keyword, @RequestParam(required = false) BoardCategory category, @RequestParam(required = false) BoardStatus status) {
-        List<BoardResDto> dto;
-
-        if (keyword != null && !keyword.isEmpty()) {
-            // 키워드로 게시글 제목 검색
-            dto = boardService.searchBoardsByTitle(keyword);
-        }
-        else if (category != null && status != null) {
-            // 카테고리 + 상태 조합 검색
-            dto = boardService.getBoardsByCategoryAndStatus(category, status);
-        } else if (category != null) {
-            // 게시글 카테고리 검색
-            dto = boardService.getBoardsByCategory(category);
-        } else if (status != null) {
-            // 현재 게시글 상태 검색
-            dto = boardService.getBoardsByStatus(status);
-        } else {
-            // 모든 게시글 조회
-            dto = boardService.getAllBoards();
-        }
+        List<BoardResDto> dto = boardService.getFilteredBoards(keyword, category, status);
         return new ResponseEntity<>(new CommonResDto<>("게시글 조회 성공", dto), HttpStatus.OK);
     }
 

--- a/src/main/java/com/soongsil/soongpal/board/domain/Board.java
+++ b/src/main/java/com/soongsil/soongpal/board/domain/Board.java
@@ -27,13 +27,13 @@ public class Board extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private BoardStatus status;
+    private BoardCategory category;
 
     public void update(Board board) {
         this.title = board.getTitle();
         this.content = board.getContent();
         this.url = board.getUrl();
         this.location = board.getLocation();
-        this.status = board.getStatus();
+        this.category = board.getCategory();
     }
 }

--- a/src/main/java/com/soongsil/soongpal/board/domain/Board.java
+++ b/src/main/java/com/soongsil/soongpal/board/domain/Board.java
@@ -21,6 +21,8 @@ public class Board extends BaseEntity {
     @Lob
     private String content;
 
+    private Integer price;
+
     private String url;
 
     private String location;
@@ -36,6 +38,7 @@ public class Board extends BaseEntity {
     public void update(Board board) {
         this.title = board.getTitle();
         this.content = board.getContent();
+        this.price = board.getPrice();
         this.url = board.getUrl();
         this.location = board.getLocation();
         this.category = board.getCategory();

--- a/src/main/java/com/soongsil/soongpal/board/domain/Board.java
+++ b/src/main/java/com/soongsil/soongpal/board/domain/Board.java
@@ -29,11 +29,16 @@ public class Board extends BaseEntity {
     @Column(nullable = false)
     private BoardCategory category;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BoardStatus status;
+
     public void update(Board board) {
         this.title = board.getTitle();
         this.content = board.getContent();
         this.url = board.getUrl();
         this.location = board.getLocation();
         this.category = board.getCategory();
+        this.status = board.getStatus();
     }
 }

--- a/src/main/java/com/soongsil/soongpal/board/domain/BoardCategory.java
+++ b/src/main/java/com/soongsil/soongpal/board/domain/BoardCategory.java
@@ -1,6 +1,6 @@
 package com.soongsil.soongpal.board.domain;
 
-public enum BoardStatus {
+public enum BoardCategory {
     GROUP, // 공동 구매 게시글
     USED // 중고 거래 게시글
 }

--- a/src/main/java/com/soongsil/soongpal/board/domain/BoardStatus.java
+++ b/src/main/java/com/soongsil/soongpal/board/domain/BoardStatus.java
@@ -1,0 +1,6 @@
+package com.soongsil.soongpal.board.domain;
+
+public enum BoardStatus {
+    IN_PROGRESS, // 거래 중
+    COMPLETED // 거래 완료
+}

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardCreateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardCreateReqDto.java
@@ -1,7 +1,7 @@
 package com.soongsil.soongpal.board.dto;
 
 import com.soongsil.soongpal.board.domain.Board;
-import com.soongsil.soongpal.board.domain.BoardStatus;
+import com.soongsil.soongpal.board.domain.BoardCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -27,9 +27,9 @@ public class BoardCreateReqDto {
     @Schema(description = "모임 장소 또는 거래 위치 (선택 사항)", example = "기숙사 1층 로비")
     private String location;
 
-    @Schema(description = "게시글 상태", example = "GROUP", allowableValues = {"GROUP", "USED"})
+    @Schema(description = "게시글 카테고리 상태", example = "GROUP", allowableValues = {"GROUP", "USED"})
     @NotNull
-    private BoardStatus status;
+    private BoardCategory category;
 
     public static Board toEntity(BoardCreateReqDto boardCreateReqDto) {
         return Board.builder()
@@ -37,7 +37,7 @@ public class BoardCreateReqDto {
                 .content(boardCreateReqDto.getContent())
                 .url(boardCreateReqDto.getUrl())
                 .location(boardCreateReqDto.getLocation())
-                .status(boardCreateReqDto.getStatus())
+                .category(boardCreateReqDto.getCategory())
                 .build();
     }
 }

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardCreateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardCreateReqDto.java
@@ -32,10 +32,6 @@ public class BoardCreateReqDto {
     @NotNull
     private BoardCategory category;
 
-    @Schema(description = "게시글의 현재 거래 상태", example = "IN_PROGRESS", allowableValues = {"IN_PROGRESS, COMPLETED"})
-    @NotNull
-    private BoardStatus status;
-
     public static Board toEntity(BoardCreateReqDto boardCreateReqDto) {
         return Board.builder()
                 .title(boardCreateReqDto.getTitle())
@@ -43,7 +39,7 @@ public class BoardCreateReqDto {
                 .url(boardCreateReqDto.getUrl())
                 .location(boardCreateReqDto.getLocation())
                 .category(boardCreateReqDto.getCategory())
-                .status(boardCreateReqDto.getStatus())
+                .status(BoardStatus.IN_PROGRESS)
                 .build();
     }
 }

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardCreateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardCreateReqDto.java
@@ -2,6 +2,7 @@ package com.soongsil.soongpal.board.dto;
 
 import com.soongsil.soongpal.board.domain.Board;
 import com.soongsil.soongpal.board.domain.BoardCategory;
+import com.soongsil.soongpal.board.domain.BoardStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -31,6 +32,10 @@ public class BoardCreateReqDto {
     @NotNull
     private BoardCategory category;
 
+    @Schema(description = "게시글의 현재 거래 상태", example = "IN_PROGRESS", allowableValues = {"IN_PROGRESS, COMPLETED"})
+    @NotNull
+    private BoardStatus status;
+
     public static Board toEntity(BoardCreateReqDto boardCreateReqDto) {
         return Board.builder()
                 .title(boardCreateReqDto.getTitle())
@@ -38,6 +43,7 @@ public class BoardCreateReqDto {
                 .url(boardCreateReqDto.getUrl())
                 .location(boardCreateReqDto.getLocation())
                 .category(boardCreateReqDto.getCategory())
+                .status(boardCreateReqDto.getStatus())
                 .build();
     }
 }

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardCreateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardCreateReqDto.java
@@ -23,6 +23,10 @@ public class BoardCreateReqDto {
     @NotBlank
     private String content;
 
+    @Schema(description = "판매 상품 가격", example = "12000")
+    @NotBlank
+    private Integer price;
+
     @Schema(description = "상품 관련 URL (선택 사항)", example = "https://example.com/cola")
     private String url;
     @Schema(description = "모임 장소 또는 거래 위치 (선택 사항)", example = "기숙사 1층 로비")
@@ -36,6 +40,7 @@ public class BoardCreateReqDto {
         return Board.builder()
                 .title(boardCreateReqDto.getTitle())
                 .content(boardCreateReqDto.getContent())
+                .price(boardCreateReqDto.getPrice())
                 .url(boardCreateReqDto.getUrl())
                 .location(boardCreateReqDto.getLocation())
                 .category(boardCreateReqDto.getCategory())

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardResDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardResDto.java
@@ -2,6 +2,7 @@ package com.soongsil.soongpal.board.dto;
 
 import com.soongsil.soongpal.board.domain.Board;
 import com.soongsil.soongpal.board.domain.BoardCategory;
+import com.soongsil.soongpal.board.domain.BoardStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,6 +15,7 @@ public class BoardResDto {
     private String url;
     private String location;
     private BoardCategory category;
+    private BoardStatus status;
 
     public static BoardResDto from(Board board) {
         return BoardResDto.builder()
@@ -23,6 +25,7 @@ public class BoardResDto {
                 .url(board.getUrl())
                 .location(board.getLocation())
                 .category(board.getCategory())
+                .status(board.getStatus())
                 .build();
     }
 }

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardResDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardResDto.java
@@ -12,6 +12,7 @@ public class BoardResDto {
     private Long id;
     private String title;
     private String content;
+    private Integer price;
     private String url;
     private String location;
     private BoardCategory category;
@@ -22,6 +23,7 @@ public class BoardResDto {
                 .id(board.getId())
                 .title(board.getTitle())
                 .content(board.getContent())
+                .price(board.getPrice())
                 .url(board.getUrl())
                 .location(board.getLocation())
                 .category(board.getCategory())

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardResDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardResDto.java
@@ -1,7 +1,7 @@
 package com.soongsil.soongpal.board.dto;
 
 import com.soongsil.soongpal.board.domain.Board;
-import com.soongsil.soongpal.board.domain.BoardStatus;
+import com.soongsil.soongpal.board.domain.BoardCategory;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,7 +13,7 @@ public class BoardResDto {
     private String content;
     private String url;
     private String location;
-    private BoardStatus status;
+    private BoardCategory category;
 
     public static BoardResDto from(Board board) {
         return BoardResDto.builder()
@@ -22,7 +22,7 @@ public class BoardResDto {
                 .content(board.getContent())
                 .url(board.getUrl())
                 .location(board.getLocation())
-                .status(board.getStatus())
+                .category(board.getCategory())
                 .build();
     }
 }

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardUpdateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardUpdateReqDto.java
@@ -1,7 +1,7 @@
 package com.soongsil.soongpal.board.dto;
 
 import com.soongsil.soongpal.board.domain.Board;
-import com.soongsil.soongpal.board.domain.BoardStatus;
+import com.soongsil.soongpal.board.domain.BoardCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -32,7 +32,7 @@ public class BoardUpdateReqDto {
 
     @Schema(description = "수정할 게시글 상태", example = "USED", allowableValues = {"GROUP", "USED"})
     @NotNull
-    private BoardStatus status;
+    private BoardCategory category;
 
     public Board toEntity() {
         return Board.builder()
@@ -40,7 +40,7 @@ public class BoardUpdateReqDto {
                 .content(this.content)
                 .url(this.url)
                 .location(this.location)
-                .status(this.status)
+                .category(this.category)
                 .build();
     }
 }

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardUpdateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardUpdateReqDto.java
@@ -2,6 +2,7 @@ package com.soongsil.soongpal.board.dto;
 
 import com.soongsil.soongpal.board.domain.Board;
 import com.soongsil.soongpal.board.domain.BoardCategory;
+import com.soongsil.soongpal.board.domain.BoardStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -34,6 +35,10 @@ public class BoardUpdateReqDto {
     @NotNull
     private BoardCategory category;
 
+    @Schema(description = "수정할 게시글의 현재 거래 상태", example = "IN_PROGRESS", allowableValues = {"IN_PROGRESS, COMPLETED"})
+    @NotNull
+    private BoardStatus status;
+
     public Board toEntity() {
         return Board.builder()
                 .title(this.title)
@@ -41,6 +46,7 @@ public class BoardUpdateReqDto {
                 .url(this.url)
                 .location(this.location)
                 .category(this.category)
+                .status(this.status)
                 .build();
     }
 }

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardUpdateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardUpdateReqDto.java
@@ -4,6 +4,7 @@ import com.soongsil.soongpal.board.domain.Board;
 import com.soongsil.soongpal.board.domain.BoardCategory;
 import com.soongsil.soongpal.board.domain.BoardStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -26,6 +27,11 @@ public class BoardUpdateReqDto {
     @NotBlank
     private String content;
 
+    @Schema(description = "제품 가격", example = "12000")
+    @NotNull
+    @Min(value = 0)
+    private Integer price;
+
     @Schema(description = "수정할 관련 웹 페이지 URL (선택 사항)", example = "http://new.example.com/link")
     private String url;
     @Schema(description = "수정할 모임 장소 또는 거래 위치 (선택 사항)", example = "숭실대학교 한경직 기념관")
@@ -43,6 +49,7 @@ public class BoardUpdateReqDto {
         return Board.builder()
                 .title(this.title)
                 .content(this.content)
+                .price(this.price)
                 .url(this.url)
                 .location(this.location)
                 .category(this.category)

--- a/src/main/java/com/soongsil/soongpal/board/repository/BoardRepository.java
+++ b/src/main/java/com/soongsil/soongpal/board/repository/BoardRepository.java
@@ -1,13 +1,13 @@
 package com.soongsil.soongpal.board.repository;
 
 import com.soongsil.soongpal.board.domain.Board;
-import com.soongsil.soongpal.board.domain.BoardStatus;
+import com.soongsil.soongpal.board.domain.BoardCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
-    List<Board> findByStatus(BoardStatus status);
+    List<Board> findByCategory(BoardCategory category);
 
     List<Board> findByTitleContainingIgnoreCase(String keyword);
 }

--- a/src/main/java/com/soongsil/soongpal/board/repository/BoardRepository.java
+++ b/src/main/java/com/soongsil/soongpal/board/repository/BoardRepository.java
@@ -2,12 +2,15 @@ package com.soongsil.soongpal.board.repository;
 
 import com.soongsil.soongpal.board.domain.Board;
 import com.soongsil.soongpal.board.domain.BoardCategory;
+import com.soongsil.soongpal.board.domain.BoardStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
     List<Board> findByCategory(BoardCategory category);
+    List<Board> findByStatus(BoardStatus status);
+    List<Board> findByCategoryAndStatus(BoardCategory category, BoardStatus status);
 
     List<Board> findByTitleContainingIgnoreCase(String keyword);
 }

--- a/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
+++ b/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
@@ -74,7 +74,7 @@ public class BoardService {
                     .collect(Collectors.toList());
         } else if (status != null) {
             // 현재 게시글 상태 검색
-            return boardRepository.findByStatus(status).stream() // 이 메서드가 BoardRepository에 있다고 가정
+            return boardRepository.findByStatus(status).stream()
                     .map(BoardResDto::from)
                     .collect(Collectors.toList());
         } else {

--- a/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
+++ b/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
@@ -2,6 +2,7 @@ package com.soongsil.soongpal.board.service;
 
 import com.soongsil.soongpal.board.domain.Board;
 import com.soongsil.soongpal.board.domain.BoardCategory;
+import com.soongsil.soongpal.board.domain.BoardStatus;
 import com.soongsil.soongpal.board.dto.BoardCreateReqDto;
 import com.soongsil.soongpal.board.dto.BoardResDto;
 import com.soongsil.soongpal.board.dto.BoardUpdateReqDto;
@@ -74,4 +75,17 @@ public class BoardService {
                 .map(BoardResDto::from)
                 .collect(Collectors.toList());
     }
+
+    public List<BoardResDto> getBoardsByStatus(BoardStatus status) {
+        return boardRepository.findByStatus(status).stream()
+                .map(BoardResDto::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<BoardResDto> getBoardsByCategoryAndStatus(BoardCategory category, BoardStatus status) {
+        return boardRepository.findByCategoryAndStatus(category, status).stream()
+                .map(BoardResDto::from)
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
+++ b/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
@@ -31,19 +31,6 @@ public class BoardService {
         return BoardResDto.from(board);
     }
 
-    public List<BoardResDto> getBoardsByCategory(BoardCategory category) {
-        return boardRepository.findByCategory(category).stream()
-                .map(BoardResDto::from)
-                .collect(Collectors.toList());
-    }
-
-    public List<BoardResDto> getAllBoards() {
-        List<Board> boards = boardRepository.findAll();
-        return boards.stream()
-                .map(BoardResDto::from)
-                .toList();
-    }
-
     public BoardResDto getBoardById(Long id) {
         Board findBoard = boardRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
@@ -68,24 +55,34 @@ public class BoardService {
         return BoardResDto.from(findBoard);
     }
 
-    public List<BoardResDto> searchBoardsByTitle(String keyword) {
-        List<Board> searchBoards = boardRepository.findByTitleContainingIgnoreCase(keyword);
-
-        return searchBoards.stream()
-                .map(BoardResDto::from)
-                .collect(Collectors.toList());
-    }
-
-    public List<BoardResDto> getBoardsByStatus(BoardStatus status) {
-        return boardRepository.findByStatus(status).stream()
-                .map(BoardResDto::from)
-                .collect(Collectors.toList());
-    }
-
-    public List<BoardResDto> getBoardsByCategoryAndStatus(BoardCategory category, BoardStatus status) {
-        return boardRepository.findByCategoryAndStatus(category, status).stream()
-                .map(BoardResDto::from)
-                .collect(Collectors.toList());
+    public List<BoardResDto> getFilteredBoards(String keyword, BoardCategory category, BoardStatus status) {
+        if (keyword != null && !keyword.isEmpty()) {
+            // 키워드로 게시글 제목 검색
+            return boardRepository.findByTitleContainingIgnoreCase(keyword).stream()
+                    .map(BoardResDto::from)
+                    .collect(Collectors.toList());
+        }
+        else if (category != null && status != null) {
+            // 카테고리 + 상태 조합 검색
+            return boardRepository.findByCategoryAndStatus(category, status).stream()
+                    .map(BoardResDto::from)
+                    .collect(Collectors.toList());
+        } else if (category != null) {
+            // 게시글 카테고리 검색
+            return boardRepository.findByCategory(category).stream()
+                    .map(BoardResDto::from)
+                    .collect(Collectors.toList());
+        } else if (status != null) {
+            // 현재 게시글 상태 검색
+            return boardRepository.findByStatus(status).stream() // 이 메서드가 BoardRepository에 있다고 가정
+                    .map(BoardResDto::from)
+                    .collect(Collectors.toList());
+        } else {
+            // 모든 게시글 조회
+            return boardRepository.findAll().stream()
+                    .map(BoardResDto::from)
+                    .collect(Collectors.toList());
+        }
     }
 
 }

--- a/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
+++ b/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
@@ -1,7 +1,7 @@
 package com.soongsil.soongpal.board.service;
 
 import com.soongsil.soongpal.board.domain.Board;
-import com.soongsil.soongpal.board.domain.BoardStatus;
+import com.soongsil.soongpal.board.domain.BoardCategory;
 import com.soongsil.soongpal.board.dto.BoardCreateReqDto;
 import com.soongsil.soongpal.board.dto.BoardResDto;
 import com.soongsil.soongpal.board.dto.BoardUpdateReqDto;
@@ -30,8 +30,8 @@ public class BoardService {
         return BoardResDto.from(board);
     }
 
-    public List<BoardResDto> getBoardsByStatus(BoardStatus status) {
-        return boardRepository.findByStatus(status).stream()
+    public List<BoardResDto> getBoardsByCategory(BoardCategory category) {
+        return boardRepository.findByCategory(category).stream()
                 .map(BoardResDto::from)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
1. 기존 게시글의 종류를 알려주던 status를 category로 이름 변경하였습니다. 그리고 게시글의 현재 거래 상태를 조회할 수 있는 status를 추가하였습니다.
category -> GROUP, USED
status -> IN_PROGRESS, COMPLETED

2. 현재 거래 상태를 알려주는 status와 카테고리별 거래상태(두 가지 기준)으로 게시글을 검색하는 findByCategoryAndStatus(Category category, Status status) 메서드를 추가했습니다. 