### PR TITLE
[Feat] 게시글 페이지네이션 및 정렬 기능 구현

### DIFF
--- a/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
+++ b/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
@@ -16,11 +16,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 
 @RequiredArgsConstructor
@@ -47,8 +48,11 @@ public class BoardController {
     @Parameter(name = "keyword", description = "조회할 게시글의 제목 (선택 사항)", required = false)
     @Parameter(name = "category", description = "조회할 게시글의 카테고리 (GROUP 또는 USED) (선택 사항)", required = false)
     @Parameter(name = "status", description = "조회할 게시글의 거래 상태 (IN_PROGRESS 또는 COMPLETED) (선택 사항)", required = false)
-    public ResponseEntity<CommonResDto<List<BoardResDto>>> getBoards(@RequestParam(required = false) String keyword, @RequestParam(required = false) BoardCategory category, @RequestParam(required = false) BoardStatus status) {
-        List<BoardResDto> dto = boardService.getFilteredBoards(keyword, category, status);
+    @Parameter(name = "page", description = "조회할 페이지 번호 (0부터 시작, 기본값: 0)", example = "0")
+    @Parameter(name = "size", description = "한 페이지당 게시글 수 (기본값: 15)", example = "15")
+    @Parameter(name = "sort", description = "정렬 기준", example = "createdTime,desc")
+    public ResponseEntity<CommonResDto<Page<BoardResDto>>> getBoards(@RequestParam(required = false) String keyword, @RequestParam(required = false) BoardCategory category, @RequestParam(required = false) BoardStatus status, @PageableDefault(size = 15, sort = "createdTime", direction = org.springframework.data.domain.Sort.Direction.DESC)Pageable pageable) {
+        Page<BoardResDto> dto = boardService.getFilteredBoards(keyword, category, status, pageable);
         return new ResponseEntity<>(new CommonResDto<>("게시글 조회 성공", dto), HttpStatus.OK);
     }
 

--- a/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
+++ b/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
@@ -42,8 +42,9 @@ public class BoardController {
     @Parameter(name = "keyword", description = "조회할 게시글의 제목 (선택 사항)", required = false)
     @Parameter(name = "category", description = "조회할 게시글의 카테고리 (GROUP 또는 USED) (선택 사항)", required = false)
     @Parameter(name = "status", description = "조회할 게시글의 거래 상태 (IN_PROGRESS 또는 COMPLETED) (선택 사항)", required = false)
-    public ResponseEntity<CommonResDto<BoardPageResDto>> getBoards(@RequestParam(required = false) String keyword, @RequestParam(required = false) BoardCategory category, @RequestParam(required = false) BoardStatus status) {
-        BoardPageResDto dto = boardService.getFilteredBoards(keyword, category, status);
+    @Parameter(name = "page", description = "조회할 페이지 번호 (0부터 시작, 기본값: 0)", example = "0")
+    public ResponseEntity<CommonResDto<BoardPageResDto>> getBoards(@RequestParam(required = false) String keyword, @RequestParam(required = false) BoardCategory category, @RequestParam(required = false) BoardStatus status, @RequestParam(defaultValue = "0") int page) {
+        BoardPageResDto dto = boardService.getFilteredBoards(keyword, category, status, page);
         return new ResponseEntity<>(new CommonResDto<>("게시글 조회 성공", dto), HttpStatus.OK);
     }
 

--- a/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
+++ b/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
@@ -2,10 +2,7 @@ package com.soongsil.soongpal.board.controller;
 
 import com.soongsil.soongpal.board.domain.BoardCategory;
 import com.soongsil.soongpal.board.domain.BoardStatus;
-import com.soongsil.soongpal.board.dto.BoardCreateReqDto;
-import com.soongsil.soongpal.board.dto.BoardResDto;
-import com.soongsil.soongpal.board.dto.BoardUpdateReqDto;
-import com.soongsil.soongpal.board.dto.LikeResDto;
+import com.soongsil.soongpal.board.dto.*;
 import com.soongsil.soongpal.board.service.BoardService;
 import com.soongsil.soongpal.common.dto.CommonResDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,9 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -48,11 +42,8 @@ public class BoardController {
     @Parameter(name = "keyword", description = "조회할 게시글의 제목 (선택 사항)", required = false)
     @Parameter(name = "category", description = "조회할 게시글의 카테고리 (GROUP 또는 USED) (선택 사항)", required = false)
     @Parameter(name = "status", description = "조회할 게시글의 거래 상태 (IN_PROGRESS 또는 COMPLETED) (선택 사항)", required = false)
-    @Parameter(name = "page", description = "조회할 페이지 번호 (0부터 시작, 기본값: 0)", example = "0")
-    @Parameter(name = "size", description = "한 페이지당 게시글 수 (기본값: 15)", example = "15")
-    @Parameter(name = "sort", description = "정렬 기준", example = "createdTime,desc")
-    public ResponseEntity<CommonResDto<Page<BoardResDto>>> getBoards(@RequestParam(required = false) String keyword, @RequestParam(required = false) BoardCategory category, @RequestParam(required = false) BoardStatus status, @PageableDefault(size = 15, sort = "createdTime", direction = org.springframework.data.domain.Sort.Direction.DESC)Pageable pageable) {
-        Page<BoardResDto> dto = boardService.getFilteredBoards(keyword, category, status, pageable);
+    public ResponseEntity<CommonResDto<BoardPageResDto>> getBoards(@RequestParam(required = false) String keyword, @RequestParam(required = false) BoardCategory category, @RequestParam(required = false) BoardStatus status) {
+        BoardPageResDto dto = boardService.getFilteredBoards(keyword, category, status);
         return new ResponseEntity<>(new CommonResDto<>("게시글 조회 성공", dto), HttpStatus.OK);
     }
 

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardPageResDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardPageResDto.java
@@ -1,0 +1,34 @@
+package com.soongsil.soongpal.board.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class BoardPageResDto {
+
+    @Schema(description = "게시글 목록")
+    private List<BoardResDto> boards;
+
+    @Schema(description = "현재 페이지 번호")
+    private int currentPage;
+
+    @Schema(description = "총 페이지 수")
+    private int totalPages;
+
+    public static BoardPageResDto from(Page<BoardResDto> boardPage) {
+        return BoardPageResDto.builder()
+                .boards(boardPage.getContent())
+                .currentPage(boardPage.getNumber())
+                .totalPages(boardPage.getTotalPages())
+                .build();
+    }
+}

--- a/src/main/java/com/soongsil/soongpal/board/repository/BoardRepository.java
+++ b/src/main/java/com/soongsil/soongpal/board/repository/BoardRepository.java
@@ -5,12 +5,13 @@ import com.soongsil.soongpal.board.domain.BoardCategory;
 import com.soongsil.soongpal.board.domain.BoardStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
-    List<Board> findByCategory(BoardCategory category);
-    List<Board> findByStatus(BoardStatus status);
-    List<Board> findByCategoryAndStatus(BoardCategory category, BoardStatus status);
-
-    List<Board> findByTitleContainingIgnoreCase(String keyword);
+    Page<Board> findByCategory(BoardCategory category, Pageable pageable);
+    Page<Board> findByStatus(BoardStatus status, Pageable pageable);
+    Page<Board> findByCategoryAndStatus(BoardCategory category, BoardStatus status, Pageable pageable);
+    Page<Board> findByTitleContainingIgnoreCase(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
+++ b/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
@@ -4,10 +4,7 @@ import com.soongsil.soongpal.board.domain.Board;
 import com.soongsil.soongpal.board.domain.BoardCategory;
 import com.soongsil.soongpal.board.domain.BoardStatus;
 import com.soongsil.soongpal.board.domain.Like;
-import com.soongsil.soongpal.board.dto.BoardCreateReqDto;
-import com.soongsil.soongpal.board.dto.BoardResDto;
-import com.soongsil.soongpal.board.dto.BoardUpdateReqDto;
-import com.soongsil.soongpal.board.dto.LikeResDto;
+import com.soongsil.soongpal.board.dto.*;
 import com.soongsil.soongpal.board.repository.BoardRepository;
 import com.soongsil.soongpal.board.repository.LikeRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -15,6 +12,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,7 +58,8 @@ public class BoardService {
         return BoardResDto.from(findBoard);
     }
 
-    public Page<BoardResDto> getFilteredBoards(String keyword, BoardCategory category, BoardStatus status, Pageable pageable) {
+    public BoardPageResDto getFilteredBoards(String keyword, BoardCategory category, BoardStatus status) {
+        Pageable pageable = PageRequest.of(0, 15, Sort.by("createdTime").descending());
         Page<Board> boardsPage;
 
         if (keyword != null && !keyword.isEmpty()) {
@@ -80,7 +80,8 @@ public class BoardService {
             boardsPage = boardRepository.findAll(pageable);
         }
 
-        return boardsPage.map(BoardResDto::from);
+        Page<BoardResDto> boardPageResDto = boardsPage.map(BoardResDto::from);
+        return BoardPageResDto.from(boardPageResDto);
     }
 
     public LikeResDto addLike(Long boardId) {

--- a/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
+++ b/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
@@ -14,9 +14,11 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.data.domain.Pageable;
 import java.util.stream.Collectors;
 
 import java.util.List;
@@ -60,34 +62,28 @@ public class BoardService {
         return BoardResDto.from(findBoard);
     }
 
-    public List<BoardResDto> getFilteredBoards(String keyword, BoardCategory category, BoardStatus status) {
+    public Page<BoardResDto> getFilteredBoards(String keyword, BoardCategory category, BoardStatus status, Pageable pageable) {
+        Page<Board> boardsPage;
+
         if (keyword != null && !keyword.isEmpty()) {
             // 키워드로 게시글 제목 검색
-            return boardRepository.findByTitleContainingIgnoreCase(keyword).stream()
-                    .map(BoardResDto::from)
-                    .collect(Collectors.toList());
+            boardsPage = boardRepository.findByTitleContainingIgnoreCase(keyword, pageable);
         }
         else if (category != null && status != null) {
             // 카테고리 + 상태 조합 검색
-            return boardRepository.findByCategoryAndStatus(category, status).stream()
-                    .map(BoardResDto::from)
-                    .collect(Collectors.toList());
+            boardsPage = boardRepository.findByCategoryAndStatus(category, status, pageable);
         } else if (category != null) {
             // 게시글 카테고리 검색
-            return boardRepository.findByCategory(category).stream()
-                    .map(BoardResDto::from)
-                    .collect(Collectors.toList());
+            boardsPage = boardRepository.findByCategory(category, pageable);
         } else if (status != null) {
             // 현재 게시글 상태 검색
-            return boardRepository.findByStatus(status).stream()
-                    .map(BoardResDto::from)
-                    .collect(Collectors.toList());
+            boardsPage = boardRepository.findByStatus(status, pageable);
         } else {
             // 모든 게시글 조회
-            return boardRepository.findAll().stream()
-                    .map(BoardResDto::from)
-                    .collect(Collectors.toList());
+            boardsPage = boardRepository.findAll(pageable);
         }
+
+        return boardsPage.map(BoardResDto::from);
     }
 
     public LikeResDto addLike(Long boardId) {

--- a/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
+++ b/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
@@ -58,8 +58,8 @@ public class BoardService {
         return BoardResDto.from(findBoard);
     }
 
-    public BoardPageResDto getFilteredBoards(String keyword, BoardCategory category, BoardStatus status) {
-        Pageable pageable = PageRequest.of(0, 15, Sort.by("createdTime").descending());
+    public BoardPageResDto getFilteredBoards(String keyword, BoardCategory category, BoardStatus status, int page) {
+        Pageable pageable = PageRequest.of(page, 15, Sort.by("createdTime").descending());
         Page<Board> boardsPage;
 
         if (keyword != null && !keyword.isEmpty()) {

--- a/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
+++ b/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
@@ -19,9 +19,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import org.springframework.data.domain.Pageable;
-import java.util.stream.Collectors;
-
-import java.util.List;
 
 
 @Slf4j


### PR DESCRIPTION
게시글 목록 조회 API에 페이지네이션 및 가장 최신글이 먼저 뜨도록 정렬 기능을 추가했습니다.

@PageableDefault 어노테이션을 사용하여 페이지네이션의 기본값을 설정했습니다:
size = 15 ->한 페이지당 15개의 게시글을 보여줍니다.
sort = "createdTime" -> 게시글의 생성 날짜를 기준으로 정렬합니다.
direction = Sort.Direction.DESC -> 최신 게시글이 목록의 상단에 오도록 내림차순 정렬을 적용했습니다. 
클라이언트에서 필요에 따라 page, size, sort 쿼리 파라미터를 사용해 원하는 페이지와 정렬 방식을 지정할 수 있게 구현했습니다.

