### PR TITLE
Feature/chat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket' // 소켓
 }
 
 tasks.named('test') {

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatController.java
@@ -1,0 +1,10 @@
+package com.soongsil.soongpal.chat.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ChatController {
+
+
+
+}

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatController.java
@@ -1,10 +1,27 @@
 package com.soongsil.soongpal.chat.controller;
 
-import org.springframework.web.bind.annotation.RestController;
+import com.soongsil.soongpal.chat.dto.ChatMessageDto;
+import com.soongsil.soongpal.chat.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
 
-@RestController
+
+@Slf4j
+@RequiredArgsConstructor
+@Controller
 public class ChatController {
 
+    private final ChatService chatService;
 
+    @MessageMapping("/{roomId}")
+    @SendTo("/topic/{roomId}")
+    public ChatMessageDto sendMessage(@DestinationVariable Long roomId, ChatMessageDto dto) {
+        log.info("메시지 도착 = {}", dto.getMessage());
+        return chatService.saveMessage(roomId, dto);
+    }
 
 }

--- a/src/main/java/com/soongsil/soongpal/chat/domain/ChatMessage.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/ChatMessage.java
@@ -3,16 +3,14 @@ package com.soongsil.soongpal.chat.domain;
 
 import com.soongsil.soongpal.common.domain.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class ChatMessage extends BaseEntity {
 
     @Id

--- a/src/main/java/com/soongsil/soongpal/chat/domain/ChatMessage.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/ChatMessage.java
@@ -1,0 +1,29 @@
+package com.soongsil.soongpal.chat.domain;
+
+
+import com.soongsil.soongpal.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChatMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+
+    private Long senderId;
+    private String message;
+
+}

--- a/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoom.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoom.java
@@ -1,0 +1,29 @@
+package com.soongsil.soongpal.chat.domain;
+
+import com.soongsil.soongpal.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "chat_rooms")
+public class ChatRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
+    private List<ChatRoomUser> chatRoomUsers = new ArrayList<>();
+}

--- a/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoom.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoom.java
@@ -22,8 +22,12 @@ public class ChatRoom extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ChatRoomType type;
+
     private String name;
 
-    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatRoomUser> chatRoomUsers = new ArrayList<>();
 }

--- a/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoomType.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoomType.java
@@ -1,0 +1,6 @@
+package com.soongsil.soongpal.chat.domain;
+
+public enum ChatRoomType {
+    PRIVATE,  // 1:1
+    GROUP     // 단체방
+}

--- a/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoomUser.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoomUser.java
@@ -1,0 +1,31 @@
+package com.soongsil.soongpal.chat.domain;
+
+
+import com.soongsil.soongpal.common.domain.BaseEntity;
+import com.soongsil.soongpal.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+class ChatRoomUser extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+}

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatMessageDto.java
@@ -1,0 +1,9 @@
+package com.soongsil.soongpal.chat.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatMessageDto {
+}

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatMessageDto.java
@@ -1,9 +1,17 @@
 package com.soongsil.soongpal.chat.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class ChatMessageDto {
+
+    private Long roomId;
+    private Long senderId;
+    private String message;
+
 }

--- a/src/main/java/com/soongsil/soongpal/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/soongsil/soongpal/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,8 @@
+package com.soongsil.soongpal.chat.repository;
+
+import com.soongsil.soongpal.chat.domain.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/src/main/java/com/soongsil/soongpal/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/soongsil/soongpal/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,8 @@
+package com.soongsil.soongpal.chat.repository;
+
+import com.soongsil.soongpal.chat.domain.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/com/soongsil/soongpal/chat/service/ChatService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/ChatService.java
@@ -1,0 +1,36 @@
+package com.soongsil.soongpal.chat.service;
+
+import com.soongsil.soongpal.chat.domain.ChatMessage;
+import com.soongsil.soongpal.chat.domain.ChatRoom;
+import com.soongsil.soongpal.chat.dto.ChatMessageDto;
+import com.soongsil.soongpal.chat.repository.ChatMessageRepository;
+import com.soongsil.soongpal.chat.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Transactional
+    public ChatMessageDto saveMessage(Long roomId, ChatMessageDto dto) {
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방이 없습니다."));
+
+        ChatMessage chatMessage = ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .senderId(dto.getSenderId())
+                .message(dto.getMessage())
+                .build();
+
+        chatMessageRepository.save(chatMessage);
+
+        return dto;
+    }
+}
+

--- a/src/main/java/com/soongsil/soongpal/config/ChattingConfig.java
+++ b/src/main/java/com/soongsil/soongpal/config/ChattingConfig.java
@@ -1,0 +1,24 @@
+package com.soongsil.soongpal.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class ChattingConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry){
+        registry.addEndpoint("/ws")
+                .setAllowedOrigins("*");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry){
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+}

--- a/src/main/java/com/soongsil/soongpal/config/ChattingConfig.java
+++ b/src/main/java/com/soongsil/soongpal/config/ChattingConfig.java
@@ -12,13 +12,14 @@ public class ChattingConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry){
-        registry.addEndpoint("/ws")
-                .setAllowedOrigins("*");
+        registry.addEndpoint("/ws/chat")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry){
-        registry.enableSimpleBroker("/sub");
-        registry.setApplicationDestinationPrefixes("/pub");
+        registry.setApplicationDestinationPrefixes("/send");
+        registry.enableSimpleBroker("/topic");
     }
 }

--- a/src/main/java/com/soongsil/soongpal/user/domain/User.java
+++ b/src/main/java/com/soongsil/soongpal/user/domain/User.java
@@ -1,0 +1,21 @@
+package com.soongsil.soongpal.user.domain;
+
+import com.soongsil.soongpal.common.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class User extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nickName;
+
+}


### PR DESCRIPTION
- WebSocket + STOMP 기반 채팅 기능 구현
   - /ws/chat 엔드포인트 등록 (SockJS + STOMP)
   - /send/{roomId} 로 메시지 전송 → @MessageMapping("/{roomId}")
   - /topic/{roomId} 구독자들에게 브로드캐스트
- 채팅 엔티티 설계
    - ChatRoom, ChatRoomUser, ChatMessage 엔티티 및 JPA 리포지토리 추가
- 서비스 계층 분리
   - ChatService.saveMessage()를 통해 메시지 DB 저장 후 DTO 반환

