### PR TITLE
글로벌 예외 핸들러 구현

### DIFF
--- a/src/main/java/com/soongsil/soongpal/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/soongsil/soongpal/common/GlobalExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.soongsil.soongpal.common;
+
+
+import com.soongsil.soongpal.common.dto.CommonErrorDto;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<CommonErrorDto> IllegalArgumentExceptionHandler (IllegalArgumentException e) {
+        log.error("[exceptionHandle] IllegalArgumentException", e);
+        return new ResponseEntity<>(new CommonErrorDto(e.getMessage()),HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<CommonErrorDto> EntityNotFoundExceptionHandler (EntityNotFoundException e) {
+        log.error("[exceptionHandle] EntityNotFoundException", e);
+        return new ResponseEntity<>(new CommonErrorDto(e.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<CommonErrorDto> runtimeExceptionHandler (RuntimeException e) {
+        log.error("[exceptionHandle] RuntimeException", e);
+        return new ResponseEntity<>(new CommonErrorDto(e.getMessage()),HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonErrorDto> exceptionHandler (Exception e) {
+        log.error("[exceptionHandle] Exception", e);
+        return new ResponseEntity<>(new CommonErrorDto(e.getMessage()),HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+}

--- a/src/main/java/com/soongsil/soongpal/common/dto/CommonErrorDto.java
+++ b/src/main/java/com/soongsil/soongpal/common/dto/CommonErrorDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class CommonErrorDto<T> {
+public class CommonErrorDto {
 
     private String errorMessage;
 


### PR DESCRIPTION
1. GlobalExceptionHandler 클래스 추가
- @ControllerAdvice + @ExceptionHandler 기반 전역 예외 처리

2. 핸들링 대상 예외
- IllegalArgumentException → 400 BAD_REQUEST
- EntityNotFoundException → 400 BAD_REQUEST
- RuntimeException → 500 INTERNAL_SERVER_ERROR
- Exception (기타) → 500 INTERNAL_SERVER_ERROR

3. 공통 응답 DTO (CommonErrorDto) 를 가지고 응답 예정