### PR TITLE
Feature/chat : 실시간 채팅 시스템 구현 및 API 문서화

### DIFF
--- a/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
+++ b/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
@@ -130,7 +130,7 @@ public class BoardService {
     }
 
     public BoardPageResDto getFilteredBoards(String keyword, Long userId, BoardCategory category, BoardStatus status, int page) {
-        Pageable pageable = PageRequest.of(page, 15, Sort.by("createdTime").descending());
+        Pageable pageable = PageRequest.of(page, 15, Sort.by("createdAt").descending());
         Page<Board> boardsPage;
 
         if (keyword != null && !keyword.isEmpty()) {

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatController.java
@@ -20,7 +20,7 @@ public class ChatController {
     @MessageMapping("/{roomId}")
     @SendTo("/topic/{roomId}")
     public ChatMessageDto sendMessage(@DestinationVariable Long roomId, ChatMessageDto dto) {
-        log.info("메시지 도착 = {}", dto.getMessage());
+        log.info("메시지 도착 = {}", dto.getContent());
         return chatService.saveMessage(roomId, dto);
     }
 

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatController.java
@@ -3,6 +3,7 @@ package com.soongsil.soongpal.chat.controller;
 import com.soongsil.soongpal.chat.dto.ChatMessageReqDto;
 import com.soongsil.soongpal.chat.dto.ChatMessageResDto;
 import com.soongsil.soongpal.chat.service.ChatService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -20,7 +21,7 @@ public class ChatController {
 
     @MessageMapping("/{roomId}")
     @SendTo("/topic/{roomId}")
-    public ChatMessageResDto sendMessage(@DestinationVariable Long roomId, ChatMessageReqDto dto) {
+    public ChatMessageResDto sendMessage(@DestinationVariable Long roomId,@Valid ChatMessageReqDto dto) {
         log.info("메시지 도착 = {}", dto.getContent());
         return chatService.saveMessage(roomId, dto);
     }

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.soongsil.soongpal.chat.controller;
 
-import com.soongsil.soongpal.chat.dto.ChatMessageDto;
+import com.soongsil.soongpal.chat.dto.ChatMessageReqDto;
+import com.soongsil.soongpal.chat.dto.ChatMessageResDto;
 import com.soongsil.soongpal.chat.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +20,7 @@ public class ChatController {
 
     @MessageMapping("/{roomId}")
     @SendTo("/topic/{roomId}")
-    public ChatMessageDto sendMessage(@DestinationVariable Long roomId, ChatMessageDto dto) {
+    public ChatMessageResDto sendMessage(@DestinationVariable Long roomId, ChatMessageReqDto dto) {
         log.info("메시지 도착 = {}", dto.getContent());
         return chatService.saveMessage(roomId, dto);
     }

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatMessageController.java
@@ -1,0 +1,35 @@
+package com.soongsil.soongpal.chat.controller;
+
+import com.soongsil.soongpal.chat.dto.ChatMessageResDto;
+import com.soongsil.soongpal.chat.dto.ChatPageResDto;
+import com.soongsil.soongpal.chat.service.ChatMessageService;
+import com.soongsil.soongpal.common.dto.CommonResDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat/messages")
+public class ChatMessageController {
+
+    private final ChatMessageService chatMessageService;
+
+    @GetMapping
+    public ResponseEntity<CommonResDto<ChatPageResDto<ChatMessageResDto>>> getMessages(
+            @RequestParam Long roomId,
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        Long userId = getUserId();
+        ChatPageResDto<ChatMessageResDto> messages = chatMessageService.getMessages(roomId, userId, page);
+        return new ResponseEntity<>(new CommonResDto<>("메시지 목록을 조회했습니다.", messages), HttpStatus.OK);
+    }
+
+    private Long getUserId() {
+        return 2L;
+    }
+
+}

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatMessageController.java
@@ -4,13 +4,20 @@ import com.soongsil.soongpal.chat.dto.ChatMessageResDto;
 import com.soongsil.soongpal.chat.dto.ChatPageResDto;
 import com.soongsil.soongpal.chat.service.ChatMessageService;
 import com.soongsil.soongpal.common.dto.CommonResDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 
+@Tag(name = "채팅 메시지 API", description = "채팅 메시지 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chat/messages")
@@ -18,10 +25,19 @@ public class ChatMessageController {
 
     private final ChatMessageService chatMessageService;
 
+    @Operation(summary = "채팅 메시지 조회", description = "특정 채팅방의 메시지 목록을 페이지별로 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "메시지 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class))),
+            @ApiResponse(responseCode = "404", description = "채팅방이 존재하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class))),
+            @ApiResponse(responseCode = "403", description = "채팅방에 접근할 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    })
     @GetMapping
     public ResponseEntity<CommonResDto<ChatPageResDto<ChatMessageResDto>>> getMessages(
-            @RequestParam Long roomId,
-            @RequestParam(defaultValue = "0") int page
+            @Parameter(description = "채팅방 ID") @RequestParam Long roomId,
+            @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page
     ) {
         Long userId = getUserId();
         ChatPageResDto<ChatMessageResDto> messages = chatMessageService.getMessages(roomId, userId, page);

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
@@ -25,7 +25,8 @@ public class ChatRoomController {
     public ResponseEntity<CommonResDto<ChatRoomResDto>> createChatRoom(
             @Valid @RequestBody ChatRoomCreateReqDto dto
     ) {
-        ChatRoomResDto chatRoom = chatRoomService.createChatRoom(dto);
+        Long userId = getUserId();
+        ChatRoomResDto chatRoom = chatRoomService.createChatRoom(dto, userId);
         return new ResponseEntity<>(new CommonResDto<>("채팅방이 생성되었습니다.", chatRoom), HttpStatus.OK);
     }
 

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -33,6 +35,13 @@ public class ChatRoomController {
         Long userId = getUserId();
         ChatRoomResDto chatRoom = chatRoomService.getChatRoom(roomId, userId);
         return new ResponseEntity<>(new CommonResDto<>("채팅방 정보를 조회했습니다.", chatRoom), HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity<CommonResDto<List<ChatRoomResDto>>> getChatRooms() {
+        Long userId = getUserId();
+        List<ChatRoomResDto> chatRooms = chatRoomService.getChatRoomsByUser(userId);
+        return new ResponseEntity<>(new CommonResDto<>("채팅방 목록을 조회했습니다.", chatRooms), HttpStatus.OK);
     }
 
     private Long getUserId() {

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
@@ -26,4 +26,17 @@ public class ChatRoomController {
         return new ResponseEntity<>(new CommonResDto<>("채팅방이 생성되었습니다.", chatRoom), HttpStatus.OK);
     }
 
+    @GetMapping("/{roomId}")
+    public ResponseEntity<CommonResDto<ChatRoomResDto>> getChatRoom(
+            @PathVariable Long roomId
+    ) {
+        Long userId = getUserId();
+        ChatRoomResDto chatRoom = chatRoomService.getChatRoom(roomId, userId);
+        return new ResponseEntity<>(new CommonResDto<>("채팅방 정보를 조회했습니다.", chatRoom), HttpStatus.OK);
+    }
+
+    private Long getUserId() {
+        return 2L;
+    }
+
 }

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
@@ -4,6 +4,13 @@ import com.soongsil.soongpal.chat.dto.ChatRoomCreateReqDto;
 import com.soongsil.soongpal.chat.dto.ChatRoomResDto;
 import com.soongsil.soongpal.chat.service.ChatRoomService;
 import com.soongsil.soongpal.common.dto.CommonResDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 
+@Tag(name = "채팅방 API", description = "채팅방 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chat/rooms")
@@ -21,24 +29,43 @@ public class ChatRoomController {
     private final ChatRoomService chatRoomService;
 
 
+    @Operation(summary = "채팅방 생성", description = "새로운 채팅방을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "채팅방 생성 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class))),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    })
     @PostMapping
     public ResponseEntity<CommonResDto<ChatRoomResDto>> createChatRoom(
-            @Valid @RequestBody ChatRoomCreateReqDto dto
+            @Parameter(description = "채팅방 생성 요청 정보") @Valid @RequestBody ChatRoomCreateReqDto dto
     ) {
         Long userId = getUserId();
         ChatRoomResDto chatRoom = chatRoomService.createChatRoom(dto, userId);
         return new ResponseEntity<>(new CommonResDto<>("채팅방이 생성되었습니다.", chatRoom), HttpStatus.OK);
     }
 
+    @Operation(summary = "채팅방 조회", description = "특정 채팅방의 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "채팅방 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class))),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class))),
+            @ApiResponse(responseCode = "403", description = "해당 채팅방에 접근할 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    })
     @GetMapping("/{roomId}")
     public ResponseEntity<CommonResDto<ChatRoomResDto>> getChatRoom(
-            @PathVariable Long roomId
+            @Parameter(description = "채팅방 ID") @PathVariable Long roomId
     ) {
         Long userId = getUserId();
         ChatRoomResDto chatRoom = chatRoomService.getChatRoom(roomId, userId);
         return new ResponseEntity<>(new CommonResDto<>("채팅방 정보를 조회했습니다.", chatRoom), HttpStatus.OK);
     }
 
+    @Operation(summary = "채팅방 목록 조회", description = "사용자가 참여한 채팅방 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "채팅방 목록 조회 성공",
+            content = @Content(schema = @Schema(implementation = CommonResDto.class)))
     @GetMapping
     public ResponseEntity<CommonResDto<List<ChatRoomResDto>>> getChatRooms() {
         Long userId = getUserId();
@@ -46,22 +73,54 @@ public class ChatRoomController {
         return new ResponseEntity<>(new CommonResDto<>("채팅방 목록을 조회했습니다.", chatRooms), HttpStatus.OK);
     }
 
+    @Operation(summary = "채팅방 참가", description = "특정 채팅방에 참가합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "채팅방 참가 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class))),
+            @ApiResponse(responseCode = "404", description = "채팅방 또는 사용자를 찾을 수 없습니다",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class))),
+            @ApiResponse(responseCode = "409", description = "이미 참가한 채팅방입니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    })
     @PostMapping("/{roomId}/join")
-    public ResponseEntity<CommonResDto<String>> joinChatRoom(@PathVariable Long roomId) {
+    public ResponseEntity<CommonResDto<String>> joinChatRoom(
+            @Parameter(description = "채팅방 ID") @PathVariable Long roomId) {
         Long userId = getUserId();
         chatRoomService.joinChatRoom(roomId, userId);
         return new ResponseEntity<>(new CommonResDto<>("채팅방에 참가했습니다.", "성공"), HttpStatus.OK);
     }
 
+    @Operation(summary = "채팅방 나가기", description = "특정 채팅방에서 나갑니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "채팅방 나가기 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class))),
+            @ApiResponse(responseCode = "404", description = "채팅방이 존재하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class))),
+            @ApiResponse(responseCode = "400", description = "참가하지 않은 채팅방입니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    })
     @PostMapping("/{roomId}/leave")
-    public ResponseEntity<CommonResDto<String>> leaveChatRoom(@PathVariable Long roomId) {
+    public ResponseEntity<CommonResDto<String>> leaveChatRoom(
+            @Parameter(description = "채팅방 ID") @PathVariable Long roomId) {
         Long userId = getUserId();
         chatRoomService.leaveChatRoom(roomId, userId);
         return new ResponseEntity<>(new CommonResDto<>("채팅방을 나갔습니다.", "성공"), HttpStatus.OK);
     }
 
+    @Operation(summary = "채팅방 삭제", description = "특정 채팅방을 삭제합니다. (방장만 가능)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "채팅방 삭제 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class))),
+            @ApiResponse(responseCode = "404", description = "채팅방이 존재하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class))),
+            @ApiResponse(responseCode = "403", description = "채팅방을 삭제할 권한이 없습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class))),
+            @ApiResponse(responseCode = "400", description = "참가하지 않은 채팅방입니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class)))
+    })
     @DeleteMapping("/{roomId}")
-    public ResponseEntity<CommonResDto<String>> deleteChatRoom(@PathVariable Long roomId) {
+    public ResponseEntity<CommonResDto<String>> deleteChatRoom(
+            @Parameter(description = "채팅방 ID") @PathVariable Long roomId) {
         Long userId = getUserId();
         chatRoomService.deleteChatRoom(roomId, userId);
         return new ResponseEntity<>(new CommonResDto<>("채팅방이 삭제되었습니다.", "성공"), HttpStatus.OK);

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
@@ -51,6 +51,13 @@ public class ChatRoomController {
         return new ResponseEntity<>(new CommonResDto<>("채팅방에 참가했습니다.", "성공"), HttpStatus.OK);
     }
 
+    @PostMapping("/{roomId}/leave")
+    public ResponseEntity<CommonResDto<String>> leaveChatRoom(@PathVariable Long roomId) {
+        Long userId = getUserId();
+        chatRoomService.leaveChatRoom(roomId, userId);
+        return new ResponseEntity<>(new CommonResDto<>("채팅방을 나갔습니다.", "성공"), HttpStatus.OK);
+    }
+
     private Long getUserId() {
         return 1L;
     }

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
@@ -1,0 +1,29 @@
+package com.soongsil.soongpal.chat.controller;
+
+import com.soongsil.soongpal.chat.dto.ChatRoomCreateReqDto;
+import com.soongsil.soongpal.chat.dto.ChatRoomResDto;
+import com.soongsil.soongpal.chat.service.ChatRoomService;
+import com.soongsil.soongpal.common.dto.CommonResDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat/rooms")
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+
+    @PostMapping
+    public ResponseEntity<CommonResDto<ChatRoomResDto>> createChatRoom(
+            @RequestBody ChatRoomCreateReqDto dto
+    ) {
+        ChatRoomResDto chatRoom = chatRoomService.createChatRoom(dto);
+        return new ResponseEntity<>(new CommonResDto<>("채팅방이 생성되었습니다.", chatRoom), HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
@@ -58,6 +58,13 @@ public class ChatRoomController {
         return new ResponseEntity<>(new CommonResDto<>("채팅방을 나갔습니다.", "성공"), HttpStatus.OK);
     }
 
+    @DeleteMapping("/{roomId}")
+    public ResponseEntity<CommonResDto<String>> deleteChatRoom(@PathVariable Long roomId) {
+        Long userId = getUserId();
+        chatRoomService.deleteChatRoom(roomId, userId);
+        return new ResponseEntity<>(new CommonResDto<>("채팅방이 삭제되었습니다.", "성공"), HttpStatus.OK);
+    }
+
     private Long getUserId() {
         return 1L;
     }

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
@@ -4,6 +4,7 @@ import com.soongsil.soongpal.chat.dto.ChatRoomCreateReqDto;
 import com.soongsil.soongpal.chat.dto.ChatRoomResDto;
 import com.soongsil.soongpal.chat.service.ChatRoomService;
 import com.soongsil.soongpal.common.dto.CommonResDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +23,7 @@ public class ChatRoomController {
 
     @PostMapping
     public ResponseEntity<CommonResDto<ChatRoomResDto>> createChatRoom(
-            @RequestBody ChatRoomCreateReqDto dto
+            @Valid @RequestBody ChatRoomCreateReqDto dto
     ) {
         ChatRoomResDto chatRoom = chatRoomService.createChatRoom(dto);
         return new ResponseEntity<>(new CommonResDto<>("채팅방이 생성되었습니다.", chatRoom), HttpStatus.OK);

--- a/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/ChatRoomController.java
@@ -44,8 +44,15 @@ public class ChatRoomController {
         return new ResponseEntity<>(new CommonResDto<>("채팅방 목록을 조회했습니다.", chatRooms), HttpStatus.OK);
     }
 
+    @PostMapping("/{roomId}/join")
+    public ResponseEntity<CommonResDto<String>> joinChatRoom(@PathVariable Long roomId) {
+        Long userId = getUserId();
+        chatRoomService.joinChatRoom(roomId, userId);
+        return new ResponseEntity<>(new CommonResDto<>("채팅방에 참가했습니다.", "성공"), HttpStatus.OK);
+    }
+
     private Long getUserId() {
-        return 2L;
+        return 1L;
     }
 
 }

--- a/src/main/java/com/soongsil/soongpal/chat/domain/ChatMessage.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/ChatMessage.java
@@ -2,6 +2,7 @@ package com.soongsil.soongpal.chat.domain;
 
 
 import com.soongsil.soongpal.common.domain.BaseEntity;
+import com.soongsil.soongpal.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -11,6 +12,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(name = "chat_messages")
 public class ChatMessage extends BaseEntity {
 
     @Id
@@ -21,7 +23,15 @@ public class ChatMessage extends BaseEntity {
     @JoinColumn(name = "chat_room_id")
     private ChatRoom chatRoom;
 
-    private Long senderId;
-    private String message;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")
+    private User sender;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private MessageType messageType = MessageType.TEXT;
 
 }

--- a/src/main/java/com/soongsil/soongpal/chat/domain/ChatRole.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/ChatRole.java
@@ -1,0 +1,6 @@
+package com.soongsil.soongpal.chat.domain;
+
+public enum ChatRole {
+    OWNER,
+    MEMBER
+}

--- a/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoom.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoom.java
@@ -38,4 +38,8 @@ public class ChatRoom extends BaseEntity {
         this.chatRoomUsers.add(chatRoomUser);
     }
 
+    public void removeUser(ChatRoomUser chatRoomUser) {
+        this.chatRoomUsers.remove(chatRoomUser);
+    }
+
 }

--- a/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoom.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoom.java
@@ -2,15 +2,13 @@ package com.soongsil.soongpal.chat.domain;
 
 import com.soongsil.soongpal.common.domain.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 
+@Builder
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,6 +26,12 @@ public class ChatRoom extends BaseEntity {
 
     private String name;
 
+    @Builder.Default
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatRoomUser> chatRoomUsers = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatMessage> messages = new ArrayList<>();
+
 }

--- a/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoom.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoom.java
@@ -34,4 +34,8 @@ public class ChatRoom extends BaseEntity {
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatMessage> messages = new ArrayList<>();
 
+    public void addUser(ChatRoomUser chatRoomUser) {
+        this.chatRoomUsers.add(chatRoomUser);
+    }
+
 }

--- a/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoomUser.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoomUser.java
@@ -1,20 +1,18 @@
 package com.soongsil.soongpal.chat.domain;
 
-
 import com.soongsil.soongpal.common.domain.BaseEntity;
 import com.soongsil.soongpal.user.domain.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 
+@Builder
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-class ChatRoomUser extends BaseEntity {
+@Table(name = "chat_room_users")
+public class ChatRoomUser extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoomUser.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/ChatRoomUser.java
@@ -26,4 +26,8 @@ public class ChatRoomUser extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ChatRole role = ChatRole.MEMBER;
+
 }

--- a/src/main/java/com/soongsil/soongpal/chat/domain/MessageType.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/MessageType.java
@@ -1,0 +1,6 @@
+package com.soongsil.soongpal.chat.domain;
+
+public enum MessageType {
+    TEXT,       // 일반 텍스트
+    SYSTEM      // 시스템 메시지 (입장/퇴장 등)
+}

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatMessageDto.java
@@ -1,10 +1,14 @@
 package com.soongsil.soongpal.chat.dto;
 
+import com.soongsil.soongpal.chat.domain.ChatMessage;
+import com.soongsil.soongpal.chat.domain.ChatRoom;
+import com.soongsil.soongpal.user.domain.User;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-
+@Builder
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -12,6 +16,15 @@ public class ChatMessageDto {
 
     private Long roomId;
     private Long senderId;
-    private String message;
+    private String senderName;
+    private String content;
+
+    public static ChatMessage toEntity(ChatMessageDto dto, ChatRoom chatRoom, User sender) {
+        return ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .sender(sender)
+                .content(dto.getContent())
+                .build();
+    }
 
 }

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatMessageReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatMessageReqDto.java
@@ -4,22 +4,19 @@ import com.soongsil.soongpal.chat.domain.ChatMessage;
 import com.soongsil.soongpal.chat.domain.ChatRoom;
 import com.soongsil.soongpal.user.domain.User;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Builder
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChatMessageDto {
+public class ChatMessageReqDto {
 
     private Long roomId;
     private Long senderId;
-    private String senderName;
     private String content;
 
-    public static ChatMessage toEntity(ChatMessageDto dto, ChatRoom chatRoom, User sender) {
+    public static ChatMessage toEntity(ChatMessageReqDto dto, User sender, ChatRoom chatRoom) {
         return ChatMessage.builder()
                 .chatRoom(chatRoom)
                 .sender(sender)

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatMessageReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatMessageReqDto.java
@@ -3,6 +3,7 @@ package com.soongsil.soongpal.chat.dto;
 import com.soongsil.soongpal.chat.domain.ChatMessage;
 import com.soongsil.soongpal.chat.domain.ChatRoom;
 import com.soongsil.soongpal.user.domain.User;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,8 +13,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ChatMessageReqDto {
 
+    @NotBlank
     private Long roomId;
+
+    @NotBlank
     private Long senderId;
+
+    @NotBlank
     private String content;
 
     public static ChatMessage toEntity(ChatMessageReqDto dto, User sender, ChatRoom chatRoom) {

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatMessageReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatMessageReqDto.java
@@ -3,22 +3,27 @@ package com.soongsil.soongpal.chat.dto;
 import com.soongsil.soongpal.chat.domain.ChatMessage;
 import com.soongsil.soongpal.chat.domain.ChatRoom;
 import com.soongsil.soongpal.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "채팅 메시지 전송 요청 DTO")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatMessageReqDto {
 
+    @Schema(description = "채팅방 ID", example = "1")
     @NotBlank
     private Long roomId;
 
+    @Schema(description = "메시지 전송자 ID", example = "1")
     @NotBlank
     private Long senderId;
 
+    @Schema(description = "메시지 내용", example = "콜라 1.25L 공구하실 분 있나요? 2000원입니다")
     @NotBlank
     private String content;
 

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatMessageResDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatMessageResDto.java
@@ -1,0 +1,33 @@
+package com.soongsil.soongpal.chat.dto;
+
+import com.soongsil.soongpal.chat.domain.ChatMessage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageResDto {
+
+    private Long roomId;
+    private Long senderId;
+    private String senderName;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public static ChatMessageResDto from(ChatMessage message) {
+        return ChatMessageResDto.builder()
+                .roomId(message.getChatRoom().getId())
+                .senderId(message.getSender().getId())
+                .senderName(message.getSender().getNickName())
+                .content(message.getContent())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatPageResDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatPageResDto.java
@@ -1,6 +1,5 @@
 package com.soongsil.soongpal.chat.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,10 +17,7 @@ public class ChatPageResDto<T> {
 
     private List<T> content;
 
-    @Schema(description = "현재 페이지 번호")
     private int currentPage;
-
-    @Schema(description = "총 페이지 수")
     private int totalPages;
 
     private boolean first;

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatPageResDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatPageResDto.java
@@ -1,0 +1,39 @@
+package com.soongsil.soongpal.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class ChatPageResDto<T> {
+
+    private List<T> content;
+
+    @Schema(description = "현재 페이지 번호")
+    private int currentPage;
+
+    @Schema(description = "총 페이지 수")
+    private int totalPages;
+
+    private boolean first;
+    private boolean last;
+
+    public static <T> ChatPageResDto<T> from(Page<T> page) {
+        return ChatPageResDto.<T>builder()
+                .content(page.getContent())
+                .currentPage(page.getNumber())
+                .totalPages(page.getTotalPages())
+                .first(page.isFirst())
+                .last(page.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatRoomCreateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatRoomCreateReqDto.java
@@ -2,18 +2,23 @@ package com.soongsil.soongpal.chat.dto;
 
 import com.soongsil.soongpal.chat.domain.ChatRoom;
 import com.soongsil.soongpal.chat.domain.ChatRoomType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
+@Schema(description = "채팅방 생성 요청 DTO")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatRoomCreateReqDto {
 
+    @Schema(description = "채팅방 이름", example = "콜라 공구 채팅방")
     private String name;
+
+    @Schema(description = "채팅방 타입", example = "GROUP")
     @NotBlank
     private ChatRoomType type;
 

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatRoomCreateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatRoomCreateReqDto.java
@@ -2,6 +2,7 @@ package com.soongsil.soongpal.chat.dto;
 
 import com.soongsil.soongpal.chat.domain.ChatRoom;
 import com.soongsil.soongpal.chat.domain.ChatRoomType;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +15,7 @@ import java.util.List;
 public class ChatRoomCreateReqDto {
 
     private String name;
+    @NotBlank
     private ChatRoomType type;
     private List<Long> userIds;
 

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatRoomCreateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatRoomCreateReqDto.java
@@ -7,7 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -17,7 +16,6 @@ public class ChatRoomCreateReqDto {
     private String name;
     @NotBlank
     private ChatRoomType type;
-    private List<Long> userIds;
 
     public static ChatRoom toEntity(ChatRoomCreateReqDto dto) {
         return ChatRoom.builder()

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatRoomCreateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatRoomCreateReqDto.java
@@ -1,0 +1,26 @@
+package com.soongsil.soongpal.chat.dto;
+
+import com.soongsil.soongpal.chat.domain.ChatRoom;
+import com.soongsil.soongpal.chat.domain.ChatRoomType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRoomCreateReqDto {
+
+    private String name;
+    private ChatRoomType type;
+    private List<Long> userIds;
+
+    public static ChatRoom toEntity(ChatRoomCreateReqDto dto) {
+        return ChatRoom.builder()
+                .name(dto.getName())
+                .type(dto.getType())
+                .build();
+    }
+}

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatRoomResDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatRoomResDto.java
@@ -1,0 +1,42 @@
+package com.soongsil.soongpal.chat.dto;
+
+import com.soongsil.soongpal.chat.domain.ChatRoom;
+import com.soongsil.soongpal.chat.domain.ChatRoomType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoomResDto {
+
+    private Long id;
+    private String name;
+    private ChatRoomType type;
+    private int userCount;
+    private List<ChatRoomUserResDto> users;
+    private ChatMessageResDto lastMessage;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static ChatRoomResDto of(ChatRoom chatRoom, List<ChatRoomUserResDto> users, ChatMessageResDto lastMessage) {
+        return ChatRoomResDto.builder()
+                .id(chatRoom.getId())
+                .name(chatRoom.getName())
+                .type(chatRoom.getType())
+                .userCount(chatRoom.getChatRoomUsers().size())
+                .users(users)
+                .lastMessage(lastMessage)
+                .createdAt(chatRoom.getCreatedAt())
+                .updatedAt(chatRoom.getUpdatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/soongsil/soongpal/chat/dto/ChatRoomUserResDto.java
+++ b/src/main/java/com/soongsil/soongpal/chat/dto/ChatRoomUserResDto.java
@@ -1,0 +1,28 @@
+package com.soongsil.soongpal.chat.dto;
+
+import com.soongsil.soongpal.chat.domain.ChatRoomUser;
+import com.soongsil.soongpal.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoomUserResDto {
+
+    private Long userId;
+    private String userName;
+    private String profileImage;
+
+    public static ChatRoomUserResDto from(ChatRoomUser roomUser) {
+        User u = roomUser.getUser();
+        return ChatRoomUserResDto.builder()
+                .userId(u.getId())
+                .userName(u.getNickName())
+                .build();
+    }
+
+}

--- a/src/main/java/com/soongsil/soongpal/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/soongsil/soongpal/chat/repository/ChatMessageRepository.java
@@ -2,7 +2,15 @@ package com.soongsil.soongpal.chat.repository;
 
 import com.soongsil.soongpal.chat.domain.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    @Query("SELECT cm FROM ChatMessage cm WHERE cm.chatRoom.id = :roomId ORDER BY cm.createdAt DESC LIMIT 1")
+    Optional<ChatMessage> findLastMessageByRoomId(@Param("roomId") Long roomId);
+
 }

--- a/src/main/java/com/soongsil/soongpal/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/soongsil/soongpal/chat/repository/ChatMessageRepository.java
@@ -1,6 +1,8 @@
 package com.soongsil.soongpal.chat.repository;
 
 import com.soongsil.soongpal.chat.domain.ChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,5 +14,8 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     @Query("SELECT cm FROM ChatMessage cm WHERE cm.chatRoom.id = :roomId ORDER BY cm.createdAt DESC LIMIT 1")
     Optional<ChatMessage> findLastMessageByRoomId(@Param("roomId") Long roomId);
+
+    @Query("SELECT cm FROM ChatMessage cm WHERE cm.chatRoom.id = :roomId ORDER BY cm.createdAt DESC")
+    Page<ChatMessage> findByChatRoomId(@Param("roomId") Long roomId, Pageable pageable);
 
 }

--- a/src/main/java/com/soongsil/soongpal/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/soongsil/soongpal/chat/repository/ChatRoomRepository.java
@@ -2,7 +2,15 @@ package com.soongsil.soongpal.chat.repository;
 
 import com.soongsil.soongpal.chat.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    @Query("SELECT cr FROM ChatRoom cr JOIN cr.chatRoomUsers cru WHERE cr.id = :roomId AND cru.user.id = :userId")
+    Optional<ChatRoom> findChatRoomByIdAndUserId(@Param("roomId") Long roomId, @Param("userId") Long userId);
+
 }

--- a/src/main/java/com/soongsil/soongpal/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/soongsil/soongpal/chat/repository/ChatRoomRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -12,5 +13,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     @Query("SELECT cr FROM ChatRoom cr JOIN cr.chatRoomUsers cru WHERE cr.id = :roomId AND cru.user.id = :userId")
     Optional<ChatRoom> findChatRoomByIdAndUserId(@Param("roomId") Long roomId, @Param("userId") Long userId);
+
+    @Query("SELECT cr FROM ChatRoom cr JOIN cr.chatRoomUsers cru WHERE cru.user.id = :userId ORDER BY cr.updatedAt DESC")
+    List<ChatRoom> findChatRoomsByUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/com/soongsil/soongpal/chat/repository/ChatRoomUserRepository.java
+++ b/src/main/java/com/soongsil/soongpal/chat/repository/ChatRoomUserRepository.java
@@ -3,6 +3,11 @@ package com.soongsil.soongpal.chat.repository;
 import com.soongsil.soongpal.chat.domain.ChatRoomUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 
 public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long> {
+
+    Optional<ChatRoomUser> findByChatRoomIdAndUserId(Long roomId, Long userId);
+
 }

--- a/src/main/java/com/soongsil/soongpal/chat/repository/ChatRoomUserRepository.java
+++ b/src/main/java/com/soongsil/soongpal/chat/repository/ChatRoomUserRepository.java
@@ -1,0 +1,8 @@
+package com.soongsil.soongpal.chat.repository;
+
+import com.soongsil.soongpal.chat.domain.ChatRoomUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long> {
+}

--- a/src/main/java/com/soongsil/soongpal/chat/service/ChatMessageService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/ChatMessageService.java
@@ -1,0 +1,37 @@
+package com.soongsil.soongpal.chat.service;
+
+import com.soongsil.soongpal.chat.dto.ChatMessageResDto;
+import com.soongsil.soongpal.chat.dto.ChatPageResDto;
+import com.soongsil.soongpal.chat.repository.ChatMessageRepository;
+import com.soongsil.soongpal.chat.repository.ChatRoomUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomUserRepository chatRoomUserRepository;
+
+    public ChatPageResDto<ChatMessageResDto> getMessages(Long roomId, Long userId, int page) {
+        Pageable pageable = PageRequest.of(page, 15, Sort.by("createdAt").descending());
+        boolean hasAccess = chatRoomUserRepository.findByChatRoomIdAndUserId(roomId, userId).isPresent();
+        if (!hasAccess) {
+            throw new IllegalArgumentException("접근 권한이 없는 채팅방입니다.");
+        }
+
+        Page<ChatMessageResDto> messages = chatMessageRepository.findByChatRoomId(roomId, pageable)
+                .map(ChatMessageResDto::from);
+        return  ChatPageResDto.from(messages);
+    }
+
+
+}

--- a/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
@@ -11,6 +11,7 @@ import com.soongsil.soongpal.chat.repository.ChatRoomRepository;
 import com.soongsil.soongpal.chat.repository.ChatRoomUserRepository;
 import com.soongsil.soongpal.user.domain.User;
 import com.soongsil.soongpal.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,6 +57,25 @@ public class ChatRoomService {
         return chatRooms.stream()
                 .map(this::convertToChatRoomResDto)
                 .toList();
+    }
+
+    public void joinChatRoom(Long roomId, Long userId) {
+        ChatRoom findChatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방이 없습니다."));
+
+        User findUser = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+        boolean alreadyJoined = chatRoomUserRepository.findByChatRoomIdAndUserId(roomId, userId).isPresent();
+        if (alreadyJoined) {
+            throw new IllegalArgumentException("이미 참가한 채팅방입니다.");
+        }
+
+        ChatRoomUser roomUser = ChatRoomUser.builder()
+                .chatRoom(findChatRoom)
+                .user(findUser)
+                .build();
+        chatRoomUserRepository.save(roomUser);
     }
 
     private ChatRoomResDto convertToChatRoomResDto(ChatRoom chatRoom) {

--- a/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
@@ -51,6 +51,13 @@ public class ChatRoomService {
         return convertToChatRoomResDto(chatRoom);
     }
 
+    public List<ChatRoomResDto> getChatRoomsByUser(Long userId) {
+        List<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsByUserId(userId);
+        return chatRooms.stream()
+                .map(this::convertToChatRoomResDto)
+                .toList();
+    }
+
     private ChatRoomResDto convertToChatRoomResDto(ChatRoom chatRoom) {
         List<ChatRoomUserResDto> users = chatRoom.getChatRoomUsers().stream()
                 .map(ChatRoomUserResDto::from)

--- a/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
@@ -9,9 +9,10 @@ import com.soongsil.soongpal.chat.dto.ChatRoomUserResDto;
 import com.soongsil.soongpal.chat.repository.ChatMessageRepository;
 import com.soongsil.soongpal.chat.repository.ChatRoomRepository;
 import com.soongsil.soongpal.chat.repository.ChatRoomUserRepository;
+import com.soongsil.soongpal.common.exception.ChatErrorCode;
+import com.soongsil.soongpal.common.exception.ChatException;
 import com.soongsil.soongpal.user.domain.User;
 import com.soongsil.soongpal.user.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +29,6 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomUserRepository chatRoomUserRepository;
-
 
     public ChatRoomResDto createChatRoom(ChatRoomCreateReqDto dto) {
         ChatRoom savedRoom = chatRoomRepository.save(ChatRoomCreateReqDto.toEntity(dto));
@@ -48,7 +48,7 @@ public class ChatRoomService {
 
     public ChatRoomResDto getChatRoom(Long roomId, Long userId) {
         ChatRoom chatRoom = chatRoomRepository.findChatRoomByIdAndUserId(roomId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("접근 권한이 없거나 존재하지 않는 채팅방입니다."));
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED));
         return convertToChatRoomResDto(chatRoom);
     }
 
@@ -61,14 +61,14 @@ public class ChatRoomService {
 
     public void joinChatRoom(Long roomId, Long userId) {
         ChatRoom findChatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("채팅방이 없습니다."));
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
 
         User findUser = userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new ChatException(ChatErrorCode.USER_NOT_FOUND));
 
         boolean alreadyJoined = chatRoomUserRepository.findByChatRoomIdAndUserId(roomId, userId).isPresent();
         if (alreadyJoined) {
-            throw new IllegalArgumentException("이미 참가한 채팅방입니다.");
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_ALREADY_JOINED);
         }
 
         ChatRoomUser roomUser = ChatRoomUser.builder()
@@ -80,13 +80,13 @@ public class ChatRoomService {
 
     public void leaveChatRoom(Long roomId, Long userId) {
         ChatRoomUser roomUser = chatRoomUserRepository.findByChatRoomIdAndUserId(roomId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("참가하지 않은 채팅방입니다."));
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_JOINED));
         chatRoomUserRepository.delete(roomUser);
     }
 
     public void deleteChatRoom(Long roomId, Long userId) {
         ChatRoom chatRoom = chatRoomRepository.findChatRoomByIdAndUserId(roomId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("삭제 권한이 없거나 존재하지 않는 채팅방입니다."));
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_DELETE_DENIED));
         chatRoomRepository.delete(chatRoom);
     }
 

--- a/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
@@ -1,5 +1,6 @@
 package com.soongsil.soongpal.chat.service;
 
+import com.soongsil.soongpal.chat.domain.ChatRole;
 import com.soongsil.soongpal.chat.domain.ChatRoom;
 import com.soongsil.soongpal.chat.domain.ChatRoomUser;
 import com.soongsil.soongpal.chat.dto.ChatMessageResDto;
@@ -30,18 +31,18 @@ public class ChatRoomService {
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomUserRepository chatRoomUserRepository;
 
-    public ChatRoomResDto createChatRoom(ChatRoomCreateReqDto dto) {
+    public ChatRoomResDto createChatRoom(ChatRoomCreateReqDto dto, Long userId) {
         ChatRoom savedRoom = chatRoomRepository.save(ChatRoomCreateReqDto.toEntity(dto));
+        User findUser = userRepository.findById(userId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.USER_NOT_FOUND));
 
-        List<User> users = userRepository.findAllById(dto.getUserIds());
-        for (User user : users) {
-            ChatRoomUser roomUser = ChatRoomUser.builder()
-                    .chatRoom(savedRoom)
-                    .user(user)
-                    .build();
-            chatRoomUserRepository.save(roomUser);
-            savedRoom.addUser(roomUser);
-        }
+        ChatRoomUser roomUser = ChatRoomUser.builder()
+                .chatRoom(savedRoom)
+                .user(findUser)
+                .role(ChatRole.OWNER)
+                .build();
+        chatRoomUserRepository.save(roomUser);
+        savedRoom.addUser(roomUser);
 
         return convertToChatRoomResDto(savedRoom);
     }
@@ -76,17 +77,26 @@ public class ChatRoomService {
                 .user(findUser)
                 .build();
         chatRoomUserRepository.save(roomUser);
+        findChatRoom.addUser(roomUser);
     }
 
     public void leaveChatRoom(Long roomId, Long userId) {
+        ChatRoom findChatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
         ChatRoomUser roomUser = chatRoomUserRepository.findByChatRoomIdAndUserId(roomId, userId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_JOINED));
         chatRoomUserRepository.delete(roomUser);
+        findChatRoom.removeUser(roomUser);
     }
 
     public void deleteChatRoom(Long roomId, Long userId) {
         ChatRoom chatRoom = chatRoomRepository.findChatRoomByIdAndUserId(roomId, userId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_DELETE_DENIED));
+        ChatRoomUser roomUser = chatRoomUserRepository.findByChatRoomIdAndUserId(roomId, userId)
+                        .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_JOINED));
+        if (roomUser.getRole().equals(ChatRole.MEMBER)) {
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_DELETE_DENIED);
+        }
         chatRoomRepository.delete(chatRoom);
     }
 

--- a/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
@@ -1,0 +1,60 @@
+package com.soongsil.soongpal.chat.service;
+
+import com.soongsil.soongpal.chat.domain.ChatRoom;
+import com.soongsil.soongpal.chat.domain.ChatRoomUser;
+import com.soongsil.soongpal.chat.dto.ChatMessageResDto;
+import com.soongsil.soongpal.chat.dto.ChatRoomCreateReqDto;
+import com.soongsil.soongpal.chat.dto.ChatRoomResDto;
+import com.soongsil.soongpal.chat.dto.ChatRoomUserResDto;
+import com.soongsil.soongpal.chat.repository.ChatMessageRepository;
+import com.soongsil.soongpal.chat.repository.ChatRoomRepository;
+import com.soongsil.soongpal.chat.repository.ChatRoomUserRepository;
+import com.soongsil.soongpal.user.domain.User;
+import com.soongsil.soongpal.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+    private final UserRepository userRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomUserRepository chatRoomUserRepository;
+
+
+    public ChatRoomResDto createChatRoom(ChatRoomCreateReqDto dto) {
+        ChatRoom savedRoom = chatRoomRepository.save(ChatRoomCreateReqDto.toEntity(dto));
+
+        List<User> users = userRepository.findAllById(dto.getUserIds());
+        for (User user : users) {
+            ChatRoomUser roomUser = ChatRoomUser.builder()
+                    .chatRoom(savedRoom)
+                    .user(user)
+                    .build();
+            chatRoomUserRepository.save(roomUser);
+            savedRoom.addUser(roomUser);
+        }
+
+        return convertToChatRoomResDto(savedRoom);
+    }
+
+    private ChatRoomResDto convertToChatRoomResDto(ChatRoom chatRoom) {
+        List<ChatRoomUserResDto> users = chatRoom.getChatRoomUsers().stream()
+                .map(ChatRoomUserResDto::from)
+                .toList();
+
+        ChatMessageResDto lastMessage = chatMessageRepository.findLastMessageByRoomId(chatRoom.getId())
+                .map(ChatMessageResDto::from)
+                .orElse(null);
+
+        return ChatRoomResDto.of(chatRoom, users, lastMessage);
+    }
+
+}

--- a/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
@@ -84,6 +84,12 @@ public class ChatRoomService {
         chatRoomUserRepository.delete(roomUser);
     }
 
+    public void deleteChatRoom(Long roomId, Long userId) {
+        ChatRoom chatRoom = chatRoomRepository.findChatRoomByIdAndUserId(roomId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("삭제 권한이 없거나 존재하지 않는 채팅방입니다."));
+        chatRoomRepository.delete(chatRoom);
+    }
+
     private ChatRoomResDto convertToChatRoomResDto(ChatRoom chatRoom) {
         List<ChatRoomUserResDto> users = chatRoom.getChatRoomUsers().stream()
                 .map(ChatRoomUserResDto::from)

--- a/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
@@ -45,6 +45,12 @@ public class ChatRoomService {
         return convertToChatRoomResDto(savedRoom);
     }
 
+    public ChatRoomResDto getChatRoom(Long roomId, Long userId) {
+        ChatRoom chatRoom = chatRoomRepository.findChatRoomByIdAndUserId(roomId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("접근 권한이 없거나 존재하지 않는 채팅방입니다."));
+        return convertToChatRoomResDto(chatRoom);
+    }
+
     private ChatRoomResDto convertToChatRoomResDto(ChatRoom chatRoom) {
         List<ChatRoomUserResDto> users = chatRoom.getChatRoomUsers().stream()
                 .map(ChatRoomUserResDto::from)

--- a/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/ChatRoomService.java
@@ -78,6 +78,12 @@ public class ChatRoomService {
         chatRoomUserRepository.save(roomUser);
     }
 
+    public void leaveChatRoom(Long roomId, Long userId) {
+        ChatRoomUser roomUser = chatRoomUserRepository.findByChatRoomIdAndUserId(roomId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("참가하지 않은 채팅방입니다."));
+        chatRoomUserRepository.delete(roomUser);
+    }
+
     private ChatRoomResDto convertToChatRoomResDto(ChatRoom chatRoom) {
         List<ChatRoomUserResDto> users = chatRoom.getChatRoomUsers().stream()
                 .map(ChatRoomUserResDto::from)

--- a/src/main/java/com/soongsil/soongpal/chat/service/ChatService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/ChatService.java
@@ -2,7 +2,8 @@ package com.soongsil.soongpal.chat.service;
 
 import com.soongsil.soongpal.chat.domain.ChatMessage;
 import com.soongsil.soongpal.chat.domain.ChatRoom;
-import com.soongsil.soongpal.chat.dto.ChatMessageDto;
+import com.soongsil.soongpal.chat.dto.ChatMessageReqDto;
+import com.soongsil.soongpal.chat.dto.ChatMessageResDto;
 import com.soongsil.soongpal.chat.repository.ChatMessageRepository;
 import com.soongsil.soongpal.chat.repository.ChatRoomRepository;
 import com.soongsil.soongpal.user.domain.User;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
+@Transactional
 @Service
 @RequiredArgsConstructor
 public class ChatService {
@@ -21,17 +23,18 @@ public class ChatService {
     private final ChatMessageRepository chatMessageRepository;
     private final UserRepository userRepository;
 
-    @Transactional
-    public ChatMessageDto saveMessage(Long roomId, ChatMessageDto dto) {
+
+    public ChatMessageResDto saveMessage(Long roomId, ChatMessageReqDto dto) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방이 없습니다."));
 
         User findUser = userRepository.findById(dto.getSenderId())
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
 
-        ChatMessage chatMessage = ChatMessageDto.toEntity(dto, chatRoom, findUser);
-        chatMessageRepository.save(chatMessage);
-        return dto;
+        ChatMessage chatMessage = ChatMessageReqDto.toEntity(dto, findUser, chatRoom);
+        
+        ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
+        return ChatMessageResDto.from(savedMessage);
     }
 }
 

--- a/src/main/java/com/soongsil/soongpal/chat/service/ChatService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/ChatService.java
@@ -5,6 +5,9 @@ import com.soongsil.soongpal.chat.domain.ChatRoom;
 import com.soongsil.soongpal.chat.dto.ChatMessageDto;
 import com.soongsil.soongpal.chat.repository.ChatMessageRepository;
 import com.soongsil.soongpal.chat.repository.ChatRoomRepository;
+import com.soongsil.soongpal.user.domain.User;
+import com.soongsil.soongpal.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,20 +19,18 @@ public class ChatService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public ChatMessageDto saveMessage(Long roomId, ChatMessageDto dto) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방이 없습니다."));
 
-        ChatMessage chatMessage = ChatMessage.builder()
-                .chatRoom(chatRoom)
-                .senderId(dto.getSenderId())
-                .message(dto.getMessage())
-                .build();
+        User findUser = userRepository.findById(dto.getSenderId())
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
 
+        ChatMessage chatMessage = ChatMessageDto.toEntity(dto, chatRoom, findUser);
         chatMessageRepository.save(chatMessage);
-
         return dto;
     }
 }

--- a/src/main/java/com/soongsil/soongpal/common/config/ChattingConfig.java
+++ b/src/main/java/com/soongsil/soongpal/common/config/ChattingConfig.java
@@ -1,11 +1,14 @@
 package com.soongsil.soongpal.common.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+
+@Slf4j
 @Configuration
 @EnableWebSocketMessageBroker
 public class ChattingConfig implements WebSocketMessageBrokerConfigurer {

--- a/src/main/java/com/soongsil/soongpal/common/domain/BaseEntity.java
+++ b/src/main/java/com/soongsil/soongpal/common/domain/BaseEntity.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 public abstract class BaseEntity {
     @CreationTimestamp
-    private LocalDateTime createdTime;
+    private LocalDateTime createdAt;
     @UpdateTimestamp
-    private LocalDateTime updatedTime;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/soongsil/soongpal/common/exception/ChatErrorCode.java
+++ b/src/main/java/com/soongsil/soongpal/common/exception/ChatErrorCode.java
@@ -1,0 +1,20 @@
+package com.soongsil.soongpal.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatErrorCode {
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다."),
+    CHAT_ROOM_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 채팅방에 접근할 수 없습니다."),
+    CHAT_ROOM_ALREADY_JOINED(HttpStatus.CONFLICT, "이미 참가한 채팅방입니다."),
+    CHAT_ROOM_NOT_JOINED(HttpStatus.BAD_REQUEST, "참가하지 않은 채팅방입니다."),
+    CHAT_ROOM_DELETE_DENIED(HttpStatus.FORBIDDEN, "채팅방을 삭제할 권한이 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/soongsil/soongpal/common/exception/ChatException.java
+++ b/src/main/java/com/soongsil/soongpal/common/exception/ChatException.java
@@ -1,0 +1,14 @@
+package com.soongsil.soongpal.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ChatException extends RuntimeException {
+    private final ChatErrorCode errorCode;
+
+    public ChatException(ChatErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}
+

--- a/src/main/java/com/soongsil/soongpal/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/soongsil/soongpal/common/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.soongsil.soongpal.common;
+package com.soongsil.soongpal.common.exception;
 
 
 import com.soongsil.soongpal.common.dto.CommonErrorDto;
@@ -17,6 +17,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<CommonErrorDto> IllegalArgumentExceptionHandler (IllegalArgumentException e) {
         log.error("[exceptionHandle] IllegalArgumentException", e);
+        return new ResponseEntity<>(new CommonErrorDto(e.getMessage()),HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ChatException.class)
+    public ResponseEntity<CommonErrorDto> handleChatException(ChatException e) {
+        log.error("[exceptionHandle] ChatException", e);
         return new ResponseEntity<>(new CommonErrorDto(e.getMessage()),HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/com/soongsil/soongpal/user/domain/User.java
+++ b/src/main/java/com/soongsil/soongpal/user/domain/User.java
@@ -6,9 +6,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class User extends BaseEntity {


### PR DESCRIPTION
#15 

## 요약
  WebSocket 기반의 실시간 메시지 전송과 REST API를 통한 채팅방 관리 기능을 제공합니다.
  Swagger를 통한 API 문서화를 완료했습니다.

  ## 기능

  ### 1. 채팅방 관리
  - 채팅방 생성 (GROUP/PRIVATE 타입 지원)
  - 채팅방 조회 (권한 검증 포함)
  - 채팅방 목록 조회 (사용자별)
  - 채팅방 참가/나가기
  - 채팅방 삭제 (방장 권한 필요)

  ### 2. 메시지 기능
  -  실시간 메시지 전송 (WebSocket)
  -  메시지 히스토리 조회 (페이지네이션)
  -  마지막 메시지 표시

  ## 주요 컴포넌트

  ### 1. 엔티티
  - `ChatRoom`: 채팅방 엔티티 (타입, 사용자 관리)
  - `ChatMessage`: 메시지 엔티티
  - `ChatRoomUser`: 채팅방-사용자 연관 관계
  - `ChatRole`: 역할 정의 (OWNER, MEMBER)

  ### 2. 컨트롤러
  - `ChatController`: WebSocket 메시지 처리
  - `ChatRoomController`: 채팅방 CRUD API
  - `ChatMessageController`: 메시지 조회 API

  ## API 문서화

  - 모든 REST API에 Swagger 어노테이션 적용
  - 요청 스키마 정의
  - 예외 상황별 에러 코드 및 메시지 명시

  **WebSocket 엔드포인트** (스웨거 X)

  **SEND   /send/{roomId}                # 메시지 전송
  SUBSCRIBE /topic/{roomId}           # 메시지 수신**


