### PR TITLE
feature/user refactor: 게시판 기능에 사용자 인증 및 이미지 ID 연동

### DIFF
--- a/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
+++ b/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
@@ -15,6 +15,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -126,7 +128,8 @@ public class BoardController {
     }
 
     private Long getUserId() {
-        return 1L;
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return Long.parseLong(authentication.getName());
     }
 
 

--- a/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
+++ b/src/main/java/com/soongsil/soongpal/board/controller/BoardController.java
@@ -129,6 +129,11 @@ public class BoardController {
 
     private Long getUserId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || "anonymousUser".equals(authentication.getPrincipal())) {
+            return 0L;
+        }
+
         return Long.parseLong(authentication.getName());
     }
 

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardCreateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardCreateReqDto.java
@@ -27,7 +27,7 @@ public class BoardCreateReqDto {
 
     @Schema(description = "판매 상품 가격", example = "12000")
     @NotNull
-    @Min(100)
+    @Min(value = 0)
     private Integer price;
 
     @Schema(description = "상품 관련 URL (선택 사항)", example = "https://example.com/cola")

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardImageDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardImageDto.java
@@ -1,0 +1,15 @@
+package com.soongsil.soongpal.board.dto;
+
+import com.soongsil.soongpal.board.domain.BoardImage;
+import lombok.Getter;
+
+@Getter
+public class BoardImageDto {
+    private Long id;
+    private String imageUrl;
+
+    public BoardImageDto(BoardImage boardImage) {
+        this.id = boardImage.getId();
+        this.imageUrl = boardImage.getImageUrl();
+    }
+}

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardResDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardResDto.java
@@ -25,7 +25,7 @@ public class BoardResDto {
 
     private String authorNickname;
     private LocalDateTime createdAt;
-    private List<String> imageUrls;
+    private List<BoardImageDto> images;
 
     private Integer likeCount;
     private boolean liked;
@@ -44,9 +44,9 @@ public class BoardResDto {
                 .liked(liked)
                 .authorNickname(board.getUser().getNickName())
                 .createdAt(board.getCreatedAt())
-                .imageUrls(board.getBoardImages().stream()
-                    .map(BoardImage::getImageUrl)
-                    .collect(Collectors.toList()))
+                .images(board.getBoardImages().stream()
+                        .map(BoardImageDto::new)
+                        .collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardResDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardResDto.java
@@ -2,9 +2,14 @@ package com.soongsil.soongpal.board.dto;
 
 import com.soongsil.soongpal.board.domain.Board;
 import com.soongsil.soongpal.board.domain.BoardCategory;
+import com.soongsil.soongpal.board.domain.BoardImage;
 import com.soongsil.soongpal.board.domain.BoardStatus;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -17,6 +22,11 @@ public class BoardResDto {
     private String location;
     private BoardCategory category;
     private BoardStatus status;
+
+    private String authorNickname;
+    private LocalDateTime createdAt;
+    private List<String> imageUrls;
+
     private Integer likeCount;
     private boolean liked;
 
@@ -32,6 +42,11 @@ public class BoardResDto {
                 .status(board.getStatus())
                 .likeCount(likeCount)
                 .liked(liked)
+                .authorNickname(board.getUser().getNickName())
+                .createdAt(board.getCreatedAt())
+                .imageUrls(board.getBoardImages().stream()
+                    .map(BoardImage::getImageUrl)
+                    .collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/com/soongsil/soongpal/board/dto/BoardUpdateReqDto.java
+++ b/src/main/java/com/soongsil/soongpal/board/dto/BoardUpdateReqDto.java
@@ -44,16 +44,4 @@ public class BoardUpdateReqDto {
     @Schema(description = "수정할 게시글의 현재 거래 상태", example = "IN_PROGRESS", allowableValues = {"IN_PROGRESS, COMPLETED"})
     @NotNull
     private BoardStatus status;
-
-    public Board toEntity() {
-        return Board.builder()
-                .title(this.title)
-                .content(this.content)
-                .price(this.price)
-                .url(this.url)
-                .location(this.location)
-                .category(this.category)
-                .status(this.status)
-                .build();
-    }
 }

--- a/src/main/java/com/soongsil/soongpal/board/repository/BoardImageRepository.java
+++ b/src/main/java/com/soongsil/soongpal/board/repository/BoardImageRepository.java
@@ -1,0 +1,7 @@
+package com.soongsil.soongpal.board.repository;
+
+import com.soongsil.soongpal.board.domain.BoardImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardImageRepository extends JpaRepository<BoardImage, Long> {
+}

--- a/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
+++ b/src/main/java/com/soongsil/soongpal/board/service/BoardService.java
@@ -2,6 +2,7 @@ package com.soongsil.soongpal.board.service;
 
 import com.soongsil.soongpal.board.domain.*;
 import com.soongsil.soongpal.board.dto.*;
+import com.soongsil.soongpal.board.repository.BoardImageRepository;
 import com.soongsil.soongpal.board.repository.BoardRepository;
 import com.soongsil.soongpal.board.repository.LikeRepository;
 import com.soongsil.soongpal.common.file.S3Uploader;
@@ -32,6 +33,7 @@ public class BoardService {
     private final LikeRepository likeRepository;
     private final UserRepository userRepository;
     private final S3Uploader s3Uploader;
+    private final BoardImageRepository boardImageRepository;
 
     public BoardResDto createBoard(BoardCreateReqDto boardCreateReqDto, List<MultipartFile> images, Long userId) {
         User findUser = getUser(userId);
@@ -46,12 +48,14 @@ public class BoardService {
                 if (imageUrl != null) {
                     BoardImage boardImage = BoardImage.builder()
                             .imageUrl(imageUrl)
+                            .board(board)
                             .build();
+                    boardImageRepository.save(boardImage);
                     board.addBoardImage(boardImage);
                 }
             }
         }
-
+        Board savedBoard = boardRepository.findById(board.getId()).get();
         return BoardResDto.from(board, 0, false);
     }
 

--- a/src/main/java/com/soongsil/soongpal/common/config/SecurityConfig.java
+++ b/src/main/java/com/soongsil/soongpal/common/config/SecurityConfig.java
@@ -39,7 +39,10 @@ public class SecurityConfig {
                             "/error",
                             "/oauth2/**",
                             "/login/oauth2/code/**",
-                            "/api/auth/**"
+                            "/api/auth/**",
+                            "/swagger-ui.html",
+                            "/swagger-ui/**",
+                            "/v3/api-docs/**"
                     ).permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/board/**").permitAll()
                     .anyRequest().authenticated()

--- a/src/main/java/com/soongsil/soongpal/common/config/SecurityConfig.java
+++ b/src/main/java/com/soongsil/soongpal/common/config/SecurityConfig.java
@@ -7,19 +7,15 @@ import com.soongsil.soongpal.user.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer; // csrf disable 방식 변경
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
@@ -45,6 +41,7 @@ public class SecurityConfig {
                             "/login/oauth2/code/**",
                             "/api/auth/**"
                     ).permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/board/**").permitAll()
                     .anyRequest().authenticated()
             )
             .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/soongsil/soongpal/common/config/WebConfig.java
+++ b/src/main/java/com/soongsil/soongpal/common/config/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("https://soongpal.shop", "http://localhost:5173")
+                .allowedOrigins("https://soongpal.shop", "http://localhost:5173/")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/java/com/soongsil/soongpal/common/config/WebConfig.java
+++ b/src/main/java/com/soongsil/soongpal/common/config/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("https://soongpal.shop", "http://localhost:5173/")
+                .allowedOrigins("https://soongpal.shop", "http://localhost:5173")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);


### PR DESCRIPTION
## 목적 
기존 게시판 기능에 사용자 인증 시스템을 통합하고 게시글 이미지를 관리하는 데 필요한 모든 정보를 API 응답에 포함하도록 개선했습니다.

## 작업 상세 내용
1. 게시판 기능에 사용자 인증 연동
accessToken에 담긴 실제 로그인된 사용자의 ID를 가져오도록 getUserId() 메서드를 구현했습니다.

이제 게시글 생성/수정/삭제 시, API를 요청한 사용자의 정보가 정확하게 반영되며 작성자 본인만 수정/삭제할 수 있도록 동작합니다.

2. API 응답(DTO) 수정
게시글 응답에 이미지의 고유 ID와 URL을 모두 포함하기 위해 BoardImageDto를 새로 생성했습니다.

기존 BoardResDto가 이미지 URL 목록(List<String>) 대신 List<BoardImageDto>를 반환하도록 수정했습니다.

이 변경으로, 프론트엔드에서 게시글 수정 시 삭제할 이미지를 순서가 아닌 고유 ID로 식별할 수 있게 되었습니다.

## 참고 사항
모든 게시글 관련 작업은 실제 로그인된 사용자를 기준으로 수행됩니다.