### PR TITLE
feat: FCM 알림 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ build/
 bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
+!**/src/main/resources/
+!**/src/test/resources/
 
 ### IntelliJ IDEA ###
 .idea
@@ -41,3 +43,4 @@ out/
 
 *.yaml
 *.yml
+**/*firebase*adminsdk*.json

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/soongsil/soongpal/chat/controller/rest/ChatMessageController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/rest/ChatMessageController.java
@@ -1,4 +1,4 @@
-package com.soongsil.soongpal.chat.controller;
+package com.soongsil.soongpal.chat.controller.rest;
 
 import com.soongsil.soongpal.chat.dto.ChatMessageResDto;
 import com.soongsil.soongpal.chat.dto.ChatPageResDto;

--- a/src/main/java/com/soongsil/soongpal/chat/controller/rest/ChatRoomController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/rest/ChatRoomController.java
@@ -1,4 +1,4 @@
-package com.soongsil.soongpal.chat.controller;
+package com.soongsil.soongpal.chat.controller.rest;
 
 import com.soongsil.soongpal.chat.dto.ChatRoomCreateReqDto;
 import com.soongsil.soongpal.chat.dto.ChatRoomResDto;

--- a/src/main/java/com/soongsil/soongpal/chat/repository/ChatRoomUserRepository.java
+++ b/src/main/java/com/soongsil/soongpal/chat/repository/ChatRoomUserRepository.java
@@ -3,11 +3,13 @@ package com.soongsil.soongpal.chat.repository;
 import com.soongsil.soongpal.chat.domain.ChatRoomUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 
 public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long> {
 
     Optional<ChatRoomUser> findByChatRoomIdAndUserId(Long roomId, Long userId);
+    List<ChatRoomUser> findByChatRoomIdAndUserIdNot(Long roomId, Long userId);
 
 }

--- a/src/main/java/com/soongsil/soongpal/chat/service/ChatService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/ChatService.java
@@ -2,16 +2,21 @@ package com.soongsil.soongpal.chat.service;
 
 import com.soongsil.soongpal.chat.domain.ChatMessage;
 import com.soongsil.soongpal.chat.domain.ChatRoom;
+import com.soongsil.soongpal.chat.domain.ChatRoomUser;
 import com.soongsil.soongpal.chat.dto.ChatMessageReqDto;
 import com.soongsil.soongpal.chat.dto.ChatMessageResDto;
 import com.soongsil.soongpal.chat.repository.ChatMessageRepository;
 import com.soongsil.soongpal.chat.repository.ChatRoomRepository;
+import com.soongsil.soongpal.chat.repository.ChatRoomUserRepository;
+import com.soongsil.soongpal.notification.service.FCMNotificationService;
 import com.soongsil.soongpal.user.domain.User;
 import com.soongsil.soongpal.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Transactional
@@ -21,19 +26,39 @@ public class ChatService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomUserRepository chatRoomUserRepository;
     private final UserRepository userRepository;
+    private final FCMNotificationService fcmNotificationService;
 
 
     public ChatMessageResDto saveMessage(Long roomId, ChatMessageReqDto dto) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방이 없습니다."));
 
-        User findUser = userRepository.findById(dto.getSenderId())
+        User sender = userRepository.findById(dto.getSenderId())
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
 
-        ChatMessage chatMessage = ChatMessageReqDto.toEntity(dto, findUser, chatRoom);
-
+        ChatMessage chatMessage = ChatMessageReqDto.toEntity(dto, sender, chatRoom);
         ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
+
+        sendNotificationToOtherUsers(roomId, dto.getSenderId(), sender.getNickName(), dto.getContent());
+
         return ChatMessageResDto.from(savedMessage);
+    }
+
+    private void sendNotificationToOtherUsers(Long roomId, Long senderId, String senderName, String message) {
+        List<ChatRoomUser> otherUsers = chatRoomUserRepository.findByChatRoomIdAndUserIdNot(roomId, senderId);
+        
+        for (ChatRoomUser chatRoomUser : otherUsers) {
+            User user = chatRoomUser.getUser();
+            if (user.getFcmToken() != null && !user.getFcmToken().isEmpty()) {
+                fcmNotificationService.sendChatNotification(
+                    user.getFcmToken(),
+                    senderName,
+                    message,
+                    roomId
+                );
+            }
+        }
     }
 }

--- a/src/main/java/com/soongsil/soongpal/common/config/FirebaseConfig.java
+++ b/src/main/java/com/soongsil/soongpal/common/config/FirebaseConfig.java
@@ -1,0 +1,43 @@
+package com.soongsil.soongpal.common.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Value("${firebase.config.path}")
+    private String firebaseConfigPath;
+
+    @PostConstruct
+    public void initialize() {
+        try {
+            if (FirebaseApp.getApps().isEmpty()) {
+                GoogleCredentials credentials = GoogleCredentials
+                        .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream());
+                
+                FirebaseOptions options = FirebaseOptions.builder()
+                        .setCredentials(credentials)
+                        .build();
+                
+                FirebaseApp.initializeApp(options);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Firebase 초기화 실패", e);
+        }
+    }
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+        return FirebaseMessaging.getInstance();
+    }
+}

--- a/src/main/java/com/soongsil/soongpal/notification/controller/NotificationController.java
+++ b/src/main/java/com/soongsil/soongpal/notification/controller/NotificationController.java
@@ -1,0 +1,32 @@
+package com.soongsil.soongpal.notification.controller;
+
+import com.soongsil.soongpal.notification.dto.NotificationTestRequestDto;
+import com.soongsil.soongpal.notification.service.FCMNotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/*
+ * 관리자 테스트용
+ */
+@Tag(name = "알림", description = "FCM 알림 테스트 관련 API")
+@RestController
+@RequestMapping("/api/admin/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final FCMNotificationService fcmNotificationService;
+
+    @Operation(summary = "FCM 알림 테스트", description = "지정된 FCM 토큰으로 테스트 알림을 전송합니다.")
+    @PostMapping("/test")
+    public ResponseEntity<String> sendTestNotification(@RequestBody NotificationTestRequestDto request) {
+        fcmNotificationService.sendNotificationToUser(
+            request.getFcmToken(),
+            request.getTitle(),
+            request.getBody()
+        );
+        return ResponseEntity.ok("알림 전송 완료");
+    }
+}

--- a/src/main/java/com/soongsil/soongpal/notification/dto/NotificationTestRequestDto.java
+++ b/src/main/java/com/soongsil/soongpal/notification/dto/NotificationTestRequestDto.java
@@ -1,0 +1,15 @@
+package com.soongsil.soongpal.notification.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+ * 관리자 테스트용
+ */
+@Getter
+@NoArgsConstructor
+public class NotificationTestRequestDto {
+    private String fcmToken;
+    private String title;
+    private String body;
+}

--- a/src/main/java/com/soongsil/soongpal/notification/service/FCMNotificationService.java
+++ b/src/main/java/com/soongsil/soongpal/notification/service/FCMNotificationService.java
@@ -1,0 +1,52 @@
+package com.soongsil.soongpal.notification.service;
+
+import com.google.firebase.messaging.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FCMNotificationService {
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    public void sendNotificationToUser(String fcmToken, String title, String body) {
+        try {
+            Message message = Message.builder()
+                    .setNotification(Notification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build())
+                    .setToken(fcmToken)
+                    .build();
+
+            String response = firebaseMessaging.send(message);
+            log.info("FCM 알림 전송 성공: {}", response);
+        } catch (Exception e) {
+            log.error("FCM 알림 전송 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    public void sendChatNotification(String fcmToken, String senderName, String message, Long roomId) {
+        try {
+            Message fcmMessage = Message.builder()
+                    .setNotification(Notification.builder()
+                            .setTitle(senderName + "님의 메시지")
+                            .setBody(message)
+                            .build())
+                    .putData("type", "chat")
+                    .putData("roomId", roomId.toString())
+                    .putData("senderName", senderName)
+                    .setToken(fcmToken)
+                    .build();
+
+            String response = firebaseMessaging.send(fcmMessage);
+            log.info("채팅 FCM 알림 전송 성공: {}", response);
+        } catch (Exception e) {
+            log.error("채팅 FCM 알림 전송 실패: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/soongsil/soongpal/user/controller/UserController.java
+++ b/src/main/java/com/soongsil/soongpal/user/controller/UserController.java
@@ -61,4 +61,15 @@ public class UserController {
 
         return ResponseEntity.ok("로그아웃되었습니다.");
     }
+
+    @Operation(summary = "FCM 토큰 업데이트", description = "사용자의 FCM 토큰을 업데이트합니다.")
+    @PatchMapping("/fcm-token")
+    public ResponseEntity<String> updateFcmToken(@RequestParam String fcmToken) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = Long.parseLong(authentication.getName());
+
+        authService.updateFcmToken(userId, fcmToken);
+
+        return ResponseEntity.ok("FCM 토큰이 업데이트되었습니다.");
+    }
 }

--- a/src/main/java/com/soongsil/soongpal/user/domain/User.java
+++ b/src/main/java/com/soongsil/soongpal/user/domain/User.java
@@ -23,6 +23,7 @@ public class User extends BaseEntity {
   
     private String email;
     private String refreshToken;
+    private String fcmToken;
    
   
     @Builder
@@ -38,6 +39,10 @@ public class User extends BaseEntity {
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
     }
 
 }

--- a/src/main/java/com/soongsil/soongpal/user/service/AuthService.java
+++ b/src/main/java/com/soongsil/soongpal/user/service/AuthService.java
@@ -113,6 +113,13 @@ public class AuthService {
         user.updateRefreshToken(null);
     }
 
+    @Transactional
+    public void updateFcmToken(Long userId, String fcmToken) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다. ID: " + userId));
+        user.updateFcmToken(fcmToken);
+    }
+
     public TokenRefreshResponseDto reissueTokens(String refreshToken) {
         if (!jwtTokenProvider.validateToken(refreshToken)) {
             throw new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.");


### PR DESCRIPTION
#35 

  ## Summary
  - FCM(Firebase Cloud Messaging) 푸시 알림 기능 구현
  - 채팅 메시지 수신 시 자동 알림 전송
  - 관리자 테스트용 API 추가

  ## 주요 변경사항
  - `FCMNotificationService`: 개별/채팅 알림 전송 기능
  - `NotificationController`: 관리자 테스트용 API (`/api/admin/notifications/test`)
  - `FirebaseConfig`: Firebase 초기화 및 설정
  - User 엔티티 FCM 토큰 저장/업데이트 기능
