### PR TITLE
feat: fcm Token List형식으로 변경

### DIFF
--- a/src/main/java/com/soongsil/soongpal/chat/controller/rest/DeviceTokenController.java
+++ b/src/main/java/com/soongsil/soongpal/chat/controller/rest/DeviceTokenController.java
@@ -1,0 +1,51 @@
+package com.soongsil.soongpal.chat.controller.rest;
+
+import com.soongsil.soongpal.chat.service.DeviceTokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/fcm")
+public class DeviceTokenController {
+
+    private final DeviceTokenService deviceTokenService;
+
+    @Operation(summary = "FCM 토큰 삭제", description = "사용자의 FCM 토큰을 삭제합니다.")
+    @DeleteMapping
+    public ResponseEntity<String> deleteFcmToken(@RequestParam String fcmToken) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = Long.parseLong(authentication.getName());
+
+        deviceTokenService.deleteFcmToken(userId, fcmToken);
+
+        return ResponseEntity.ok("FCM 토큰이 삭제되었습니다.");
+    }
+
+    @Operation(summary = "알림 켜기", description = "특정 디바이스의 알림을 활성화합니다.")
+    @PatchMapping("/enable")
+    public ResponseEntity<String> enableNotification(@RequestParam String fcmToken) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = Long.parseLong(authentication.getName());
+
+        deviceTokenService.enableNotification(userId, fcmToken);
+
+        return ResponseEntity.ok("알림이 켜졌습니다.");
+    }
+
+    @Operation(summary = "알림 끄기", description = "특정 디바이스의 알림을 비활성화합니다.")
+    @PatchMapping("/disable")
+    public ResponseEntity<String> disableNotification(@RequestParam String fcmToken) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = Long.parseLong(authentication.getName());
+
+        deviceTokenService.disableNotification(userId, fcmToken);
+
+        return ResponseEntity.ok("알림이 꺼졌습니다.");
+    }
+
+}

--- a/src/main/java/com/soongsil/soongpal/chat/domain/fcm/DeviceToken.java
+++ b/src/main/java/com/soongsil/soongpal/chat/domain/fcm/DeviceToken.java
@@ -1,0 +1,38 @@
+package com.soongsil.soongpal.chat.domain.fcm;
+
+import com.soongsil.soongpal.common.domain.BaseEntity;
+import com.soongsil.soongpal.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Builder
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class DeviceToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private boolean notificationEnabled;
+
+    public void enableNotification() {
+        this.notificationEnabled = true;
+    }
+
+    public void disableNotification() {
+        this.notificationEnabled = false;
+    }
+
+}

--- a/src/main/java/com/soongsil/soongpal/chat/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/soongsil/soongpal/chat/repository/DeviceTokenRepository.java
@@ -1,0 +1,11 @@
+package com.soongsil.soongpal.chat.repository;
+
+import com.soongsil.soongpal.chat.domain.fcm.DeviceToken;
+import com.soongsil.soongpal.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+    Optional<DeviceToken> findByUserAndToken(User user, String token);
+}

--- a/src/main/java/com/soongsil/soongpal/chat/service/ChatService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/ChatService.java
@@ -3,6 +3,7 @@ package com.soongsil.soongpal.chat.service;
 import com.soongsil.soongpal.chat.domain.ChatMessage;
 import com.soongsil.soongpal.chat.domain.ChatRoom;
 import com.soongsil.soongpal.chat.domain.ChatRoomUser;
+import com.soongsil.soongpal.chat.domain.fcm.DeviceToken;
 import com.soongsil.soongpal.chat.dto.ChatMessageReqDto;
 import com.soongsil.soongpal.chat.dto.ChatMessageResDto;
 import com.soongsil.soongpal.chat.repository.ChatMessageRepository;
@@ -58,13 +59,14 @@ public class ChatService {
 
         for (ChatRoomUser chatRoomUser : otherUsers) {
             User user = chatRoomUser.getUser();
-            if (user.getFcmToken() != null && !user.getFcmToken().isEmpty() && user.getDeletedAt() == null) {
-                fcmNotificationService.sendChatNotification(
-                    user.getFcmToken(),
-                    senderName,
-                    message,
-                    roomId
-                );
+            if (user.getDeviceTokens() != null && !user.getDeviceTokens().isEmpty() && user.getDeletedAt() == null) {
+                for (DeviceToken token : user.getDeviceTokens()) {
+                    if (token.isNotificationEnabled()) {
+                        fcmNotificationService.sendChatNotification(
+                                token.getToken(), senderName, message, roomId
+                        );
+                    }
+                }
             }
         }
     }

--- a/src/main/java/com/soongsil/soongpal/chat/service/DeviceTokenService.java
+++ b/src/main/java/com/soongsil/soongpal/chat/service/DeviceTokenService.java
@@ -1,0 +1,60 @@
+package com.soongsil.soongpal.chat.service;
+
+import com.soongsil.soongpal.chat.domain.fcm.DeviceToken;
+import com.soongsil.soongpal.chat.repository.DeviceTokenRepository;
+import com.soongsil.soongpal.common.exception.UserErrorCode;
+import com.soongsil.soongpal.common.exception.UserException;
+import com.soongsil.soongpal.user.domain.User;
+import com.soongsil.soongpal.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class DeviceTokenService {
+
+    private final UserRepository userRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+
+    public void deleteFcmToken(Long userId, String fcmToken) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        DeviceToken findDeviceToken = deviceTokenRepository.findByUserAndToken(user, fcmToken)
+                        .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        user.removeDeviceToken(findDeviceToken);
+    }
+
+    public void enableNotification(Long userId, String fcmToken) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        Optional<DeviceToken> existingToken = deviceTokenRepository.findByUserAndToken(user, fcmToken);
+        if (existingToken.isPresent()) {
+            existingToken.get().enableNotification();
+            return;
+        }
+
+        DeviceToken deviceToken = DeviceToken.builder()
+                .token(fcmToken)
+                .user(user)
+                .notificationEnabled(true)
+                .build();
+        deviceTokenRepository.save(deviceToken);
+        user.addDeviceToken(deviceToken);
+    }
+
+    public void disableNotification(Long userId, String fcmToken) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        DeviceToken deviceToken = deviceTokenRepository.findByUserAndToken(user, fcmToken)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        deviceToken.disableNotification();
+    }
+
+}

--- a/src/main/java/com/soongsil/soongpal/user/controller/UserController.java
+++ b/src/main/java/com/soongsil/soongpal/user/controller/UserController.java
@@ -62,14 +62,4 @@ public class UserController {
         return ResponseEntity.ok("로그아웃되었습니다.");
     }
 
-    @Operation(summary = "FCM 토큰 업데이트", description = "사용자의 FCM 토큰을 업데이트합니다.")
-    @PatchMapping("/fcm-token")
-    public ResponseEntity<String> updateFcmToken(@RequestParam String fcmToken) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = Long.parseLong(authentication.getName());
-
-        authService.updateFcmToken(userId, fcmToken);
-
-        return ResponseEntity.ok("FCM 토큰이 업데이트되었습니다.");
-    }
 }

--- a/src/main/java/com/soongsil/soongpal/user/domain/User.java
+++ b/src/main/java/com/soongsil/soongpal/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.soongsil.soongpal.user.domain;
 
+import com.soongsil.soongpal.chat.domain.fcm.DeviceToken;
 import com.soongsil.soongpal.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Getter
@@ -28,8 +31,9 @@ public class User extends BaseEntity {
     private String email;
 
     private String refreshToken;
-    private String fcmToken;
-   
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DeviceToken> deviceTokens = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     private Role role;
@@ -53,9 +57,12 @@ public class User extends BaseEntity {
         this.refreshToken = refreshToken;
     }
 
+    public void addDeviceToken(DeviceToken deviceToken) {
+        this.deviceTokens.add(deviceToken);
+    }
 
-    public void updateFcmToken(String fcmToken) {
-        this.fcmToken = fcmToken;
+    public void removeDeviceToken(DeviceToken deviceToken) {
+        this.deviceTokens.remove(deviceToken);
     }
 
     public void softDelete() {

--- a/src/main/java/com/soongsil/soongpal/user/service/AuthService.java
+++ b/src/main/java/com/soongsil/soongpal/user/service/AuthService.java
@@ -2,6 +2,7 @@ package com.soongsil.soongpal.user.service;
 
 import com.soongsil.soongpal.board.repository.LikeRepository;
 import com.soongsil.soongpal.board.service.BoardService;
+import com.soongsil.soongpal.chat.repository.DeviceTokenRepository;
 import com.soongsil.soongpal.common.exception.UserErrorCode;
 import com.soongsil.soongpal.common.exception.UserException;
 import com.soongsil.soongpal.user.domain.Role;
@@ -12,7 +13,6 @@ import com.soongsil.soongpal.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
@@ -30,6 +30,7 @@ public class AuthService {
     private final LikeRepository likeRepository;
     private final BoardService boardService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final DeviceTokenRepository deviceTokenRepository;
     private final WebClient webClient = WebClient.create();
 
     @Value("${kakao-admin.key}")
@@ -68,7 +69,7 @@ public class AuthService {
         likeRepository.deleteAllByUser(user);
         boardService.softDeleteAllBoardsByUser(user);
         unlinkKakaoAccount(user.getKakaoId());
-
+        user.getDeviceTokens().clear();
         user.softDelete();
         userRepository.save(user);
     }
@@ -124,13 +125,6 @@ public class AuthService {
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         user.updateRefreshToken(null);
-    }
-
-    @Transactional
-    public void updateFcmToken(Long userId, String fcmToken) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
-        user.updateFcmToken(fcmToken);
     }
 
     public TokenRefreshResponseDto reissueTokens(String refreshToken) {


### PR DESCRIPTION
  FCM 토큰을 리스트 형식으로 변경하여 다중 디바이스 지원 및 디바이스별 알림 제어 기능 추가
  - FCM 토큰 저장 방식 변경: User.fcmToken (String) → User.deviceTokens (List)
  - DeviceToken 도메인 생성 및 notificationEnabled 필드 추가
  - FCM 관련 API 세분화:
    - PATCH /api/fcm/enable: 알림 켜기 (토큰 없으면 생성)
    - PATCH /api/fcm/disable: 알림 끄기
    - DELETE /api/fcm: 토큰 삭제
  - 알림 전송 시 notificationEnabled == true인 토큰만 필터링
